### PR TITLE
fix: harden evaluation evidence and releases for v0.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,8 +20,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.12"]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -33,9 +37,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release assets
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  distributions:
+    if: startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install build twine
+      - run: python -m build
+      - run: python -m twine check dist/*
+      - run: sha256sum dist/* > dist/SHA256SUMS
+      - name: Attach distributions and checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes are documented here. The project follows semantic versioning while the artifact and policy formats carry independent schema versions.
 
+## [0.2.1] - 2026-08-30
+
+### Fixed
+
+- Reject non-finite metric values and policy thresholds before they can enter JSON, JUnit, or SARIF evidence.
+- Fail baseline-delta checks when candidate and baseline units or metric directions do not match.
+- Reject duplicate policy check IDs so report identifiers remain unambiguous.
+- Isolate SQLite databases per pytest session so concurrent test runs cannot corrupt each other.
+
+### Changed
+
+- Update maintained GitHub Actions and development dependency ranges after successful Dependabot CI runs; pin Actions to full commit SHAs.
+- Cancel superseded CI runs on the same ref.
+- Build and attach checked Python distributions plus SHA-256 checksums when a GitHub Release is published.
+- Mark the installed Python package as typed for PEP 561-aware consumers.
+
 ## [0.2.0] - 2026-08-24
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If EvalForge supports your research or engineering work, please cite the software.
 title: EvalForge
 type: software
-version: 0.2.0
-date-released: 2026-08-24
+version: 0.2.1
+date-released: 2026-08-30
 license: MIT
 repository-code: https://github.com/jsdhwfmax/EvalForge
 url: https://github.com/jsdhwfmax/EvalForge

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install:
 	$(PYTHON) -m pip install -e ".[rag,dashboard,dev]"
 
 test:
-	pytest --cov=evalforge --cov-report=term-missing
+	pytest --cov=evalforge --cov-report=term-missing --cov-fail-under=80
 
 lint:
 	ruff check .

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 [![CI](https://github.com/jsdhwfmax/EvalForge/actions/workflows/ci.yml/badge.svg)](https://github.com/jsdhwfmax/EvalForge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-0B7285.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.9%2B-3776AB.svg)](https://www.python.org/)
+[![GitHub stars](https://img.shields.io/github/stars/jsdhwfmax/EvalForge?style=flat)](https://github.com/jsdhwfmax/EvalForge/stargazers)
 
 EvalForge turns AI evaluation results into reviewable release evidence. It includes a transparent RAG evaluator, a vendor-neutral JSON artifact, and policy-as-code gates that emit JSON, JUnit, and SARIF for existing CI systems.
 
-> Status: v0.2 alpha. The gate and offline evaluator are usable today; artifact schema 1.0 is intentionally small while interoperability feedback is collected.
+> Status: v0.2.1 alpha. The gate and offline evaluator are usable today; artifact schema 1.0 is intentionally small while interoperability feedback is collected.
 
 ## Why EvalForge?
 
@@ -105,7 +106,7 @@ evalforge run hybrid_top3 --name "Candidate" --output build/candidate.json
 ### GitHub Action
 
 ```yaml
-- uses: jsdhwfmax/EvalForge@v0.2.0
+- uses: jsdhwfmax/EvalForge@v0.2.1
   with:
     candidate: build/candidate.json
     baseline: build/baseline.json
@@ -265,6 +266,8 @@ make test
 ```
 
 Tests cover portable artifacts, policy behavior, all three CI report formats, CLI exit codes, retrieval ranking, metrics, security grading, persistence, API validation, duplicate imports, and complete multi-configuration experiments. CI runs on Python 3.9 and 3.12 and builds the Docker image.
+
+Maintainers should follow the [release checklist](docs/RELEASE_CHECKLIST.md) so tags, package metadata, distributions, checksums, and public claims remain consistent.
 
 ## Deployment
 

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: ${{ inputs.python-version }}
     - name: Install EvalForge

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -27,7 +27,9 @@ Project importance must be demonstrated, not declared. Maintainers will report o
 - documented integrations with evaluation and CI tools;
 - security reports and time to remediation.
 
-The project currently begins at zero downstream adoption. A new repository should not describe itself as critical infrastructure until those signals exist.
+### Dated adoption snapshot
+
+From its public launch on 2026-08-24 through 2026-08-30, the repository received 41 GitHub stars. That is a verifiable signal of early interest, not proof of production use or broad adoption. As of this snapshot, confirmed downstream integrations, external issues, external pull requests, external contributors, and forks remain at zero. The project will keep these categories separate rather than converting attention into an unsupported infrastructure claim.
 
 ## Twelve-month success criteria
 

--- a/docs/INTEROPERABILITY.md
+++ b/docs/INTEROPERABILITY.md
@@ -39,6 +39,10 @@ Each check names a metric, comparison, threshold, and severity:
 
 Missing candidate metrics, missing baseline metrics, and delta checks without a baseline are configuration errors and always fail. EvalForge does not silently skip a release requirement.
 
+Evidence values and policy thresholds must be finite numbers. `NaN`, positive infinity, and negative infinity are rejected because they are not portable JSON numbers and can make comparisons misleading. Policy check IDs must be unique so JUnit test cases and SARIF rules remain unambiguous.
+
+For baseline-delta checks, the candidate and baseline must declare the same unit and metric direction. EvalForge fails the check as a configuration error rather than subtracting values with incompatible semantics.
+
 ## Reports
 
 - JSON preserves every evaluated value and message for automation.
@@ -56,5 +60,6 @@ Schema version `1.0` follows these rules:
 3. Readers reject unknown top-level fields in canonical artifacts and policies to expose typos early.
 4. Flat-summary compatibility is convenience input, not a replacement for the canonical artifact.
 5. Metric semantics belong to the producer; EvalForge evaluates the declared numeric evidence and never implies scientific validity.
+6. Delta comparisons require compatible units and directions; changing either requires a new baseline or an explicit migration.
 
 Open an issue before proposing a schema change. Include a real producer/consumer use case and a migration example.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,13 @@
+# Release checklist
+
+EvalForge releases should leave public, reproducible evidence that the tagged source is usable.
+
+1. Confirm the changelog, package version, `evalforge.__version__`, README Action tag, and `CITATION.cff` agree.
+2. Run `make lint`, `make test`, `make gate-demo`, and `python -m build` from a clean checkout.
+3. Install the built wheel in a fresh environment and run the committed quality-gate example.
+4. Confirm main-branch CI and all dependency update checks are green.
+5. Create a signed or GitHub-verified tag and publish release notes that state compatibility and known limitations.
+6. Verify the release workflow attached the wheel, source distribution, and `SHA256SUMS` file.
+7. Record only verifiable adoption, compatibility, and security evidence; never infer production use from stars alone.
+
+PyPI publication is a separate step. Do not claim that `evalforge-ci` is available from PyPI until the project page and published files are publicly verifiable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "evalforge-ci"
-version = "0.2.0"
+version = "0.2.1"
 description = "Portable evaluation evidence and policy gates for RAG and AI assistants"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -39,9 +39,9 @@ dev = [
   "build>=1.2,<2",
   "coverage[toml]>=7.6,<8",
   "jsonschema>=4.23,<5",
-  "mypy>=1.11,<2",
-  "pytest>=8.2,<9",
-  "pytest-cov>=5,<7",
+  "mypy>=1.11,<3",
+  "pytest>=8.2,<10",
+  "pytest-cov>=5,<8",
   "ruff>=0.6,<1",
 ]
 
@@ -55,6 +55,9 @@ Issues = "https://github.com/jsdhwfmax/EvalForge/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+evalforge = ["py.typed"]
 
 [tool.setuptools.data-files]
 "share/evalforge/schemas" = ["schemas/*.json"]

--- a/src/evalforge/__init__.py
+++ b/src/evalforge/__init__.py
@@ -1,3 +1,3 @@
 """EvalForge: portable evaluation evidence and quality gates for AI systems."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/evalforge/artifacts.py
+++ b/src/evalforge/artifacts.py
@@ -28,18 +28,18 @@ METRIC_METADATA: Dict[str, Tuple[str, str]] = {
 
 
 class MetricValue(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
     value: float
-    unit: str = "score"
+    unit: str = Field(default="score", min_length=1)
     direction: Literal["higher", "lower", "neutral"] = "neutral"
 
 
 class ArtifactProducer(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    name: str
-    version: str
+    name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
 
 
 class ArtifactRun(BaseModel):
@@ -118,4 +118,7 @@ def load_artifact(path: Path) -> EvaluationArtifact:
 def write_artifact(path: Path, artifact: EvaluationArtifact) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = artifact.model_dump(mode="json", exclude_none=True, by_alias=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )

--- a/src/evalforge/gates.py
+++ b/src/evalforge/gates.py
@@ -2,11 +2,12 @@
 
 import json
 import operator
+from collections import Counter
 from pathlib import Path
 from typing import Callable, Dict, List, Literal, Optional
 from xml.etree import ElementTree
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from evalforge.artifacts import EvaluationArtifact
 
@@ -14,7 +15,7 @@ GateOperator = Literal["gte", "lte", "delta_gte", "delta_lte"]
 
 
 class GateCheck(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
     id: str = Field(pattern=r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
     metric: str = Field(min_length=1)
@@ -31,6 +32,14 @@ class GatePolicy(BaseModel):
     version: Literal[1] = 1
     name: str = Field(default="EvalForge quality policy", min_length=1)
     checks: List[GateCheck] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def check_ids_are_unique(self) -> "GatePolicy":
+        counts = Counter(check.id for check in self.checks)
+        duplicates = sorted(check_id for check_id, count in counts.items() if count > 1)
+        if duplicates:
+            raise ValueError("Gate check IDs must be unique: %s" % ", ".join(duplicates))
+        return self
 
 
 class CheckResult(BaseModel):
@@ -126,6 +135,28 @@ def evaluate_gate(
                     _error_result(check, "Baseline metric is missing: %s" % check.metric)
                 )
                 continue
+            if candidate_metric.unit != baseline_metric.unit:
+                results.append(
+                    _error_result(
+                        check,
+                        "Metric units do not match for %s: candidate=%s, baseline=%s"
+                        % (check.metric, candidate_metric.unit, baseline_metric.unit),
+                    )
+                )
+                continue
+            if candidate_metric.direction != baseline_metric.direction:
+                results.append(
+                    _error_result(
+                        check,
+                        "Metric directions do not match for %s: candidate=%s, baseline=%s"
+                        % (
+                            check.metric,
+                            candidate_metric.direction,
+                            baseline_metric.direction,
+                        ),
+                    )
+                )
+                continue
             baseline_value = baseline_metric.value
             observed = actual - baseline_value
 
@@ -180,7 +211,7 @@ def render_terminal(report: GateReport) -> str:
 
 def render_json(report: GateReport) -> str:
     payload = report.model_dump(mode="json", exclude_none=True)
-    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    return json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
 
 
 def render_junit(report: GateReport) -> str:
@@ -266,7 +297,7 @@ def render_sarif(report: GateReport) -> str:
             }
         ],
     }
-    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    return json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
 
 
 def write_report(path: Path, content: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,12 @@
 import os
+import shutil
 import tempfile
 from pathlib import Path
 
 import pytest
 
-TEST_DB = Path(tempfile.gettempdir()) / "evalforge_test.db"
-if TEST_DB.exists():
-    TEST_DB.unlink()
+TEST_DIR = Path(tempfile.mkdtemp(prefix="evalforge-test-"))
+TEST_DB = TEST_DIR / "evalforge_test.db"
 os.environ["EVALFORGE_DATABASE_URL"] = "sqlite:///%s" % TEST_DB
 
 from evalforge.database import Base, engine, init_db  # noqa: E402
@@ -22,8 +22,7 @@ def clean_database():
 
 def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001
     engine.dispose()
-    if TEST_DB.exists():
-        TEST_DB.unlink()
+    shutil.rmtree(TEST_DIR, ignore_errors=True)
 
 
 @pytest.fixture()

--- a/tests/test_artifacts_gates.py
+++ b/tests/test_artifacts_gates.py
@@ -1,8 +1,10 @@
 import json
+import math
 from pathlib import Path
 from xml.etree import ElementTree
 
 import jsonschema
+import pytest
 from typer.testing import CliRunner
 
 from evalforge.artifacts import artifact_from_summary, load_artifact, write_artifact
@@ -101,6 +103,79 @@ def test_missing_metric_and_baseline_are_gate_errors():
     report = evaluate_gate(needs_baseline, candidate)
     assert report.passed is False
     assert "Baseline artifact is required" in report.checks[0].message
+
+
+def test_non_finite_evidence_and_thresholds_are_rejected(tmp_path):
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(
+        json.dumps({"answer_correctness": math.nan}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="finite number"):
+        load_artifact(artifact_path)
+
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "checks": [
+                    {
+                        "id": "quality",
+                        "metric": "answer_correctness",
+                        "op": "gte",
+                        "value": math.inf,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="finite number"):
+        load_policy(policy_path)
+
+
+def test_duplicate_check_ids_are_rejected():
+    with pytest.raises(ValueError, match="Gate check IDs must be unique: quality"):
+        GatePolicy(
+            checks=[
+                GateCheck(id="quality", metric="answer_correctness", op="gte", value=0.8),
+                GateCheck(id="quality", metric="faithfulness", op="gte", value=0.8),
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    ("candidate_kwargs", "baseline_kwargs", "message"),
+    [
+        ({"unit": "ms"}, {"unit": "seconds"}, "Metric units do not match"),
+        (
+            {"direction": "lower"},
+            {"direction": "higher"},
+            "Metric directions do not match",
+        ),
+    ],
+)
+def test_delta_checks_reject_incompatible_metric_metadata(
+    candidate_kwargs, baseline_kwargs, message
+):
+    candidate = artifact_from_summary({"latency_ms": 100})
+    baseline = artifact_from_summary({"latency_ms": 110})
+    candidate.metrics["latency_ms"] = candidate.metrics["latency_ms"].model_copy(
+        update=candidate_kwargs
+    )
+    baseline.metrics["latency_ms"] = baseline.metrics["latency_ms"].model_copy(
+        update=baseline_kwargs
+    )
+    policy = GatePolicy(
+        checks=[GateCheck(id="latency", metric="latency_ms", op="delta_lte", value=0)]
+    )
+
+    report = evaluate_gate(policy, candidate, baseline)
+
+    assert report.passed is False
+    assert report.checks[0].outcome == "error"
+    assert message in report.checks[0].message
 
 
 def test_cli_writes_reports_and_uses_failure_exit_code(tmp_path):


### PR DESCRIPTION
## Problem

Portable evaluation evidence must reject ambiguous numeric inputs and remain reliable under CI and release automation.

## Changes

- reject NaN/Infinity, duplicate gate IDs, and incompatible delta metadata
- isolate concurrent test sessions
- update and pin GitHub Actions plus development dependencies
- add release assets/checksums automation and a PEP 561 marker
- document the 41-star early-interest snapshot without claiming external adoption

## Verification

- 34 tests pass with 87.97% coverage
- Ruff, mypy, actionlint, and package metadata checks pass
- two concurrent pytest sessions pass
- fresh wheel install, demo gate, pip check, and twine check pass

Artifact schema 1.0 and policy schema 1 remain unchanged.