### PR TITLE
fix: make release checksums portable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,9 @@ jobs:
       - run: python -m pip install build twine
       - run: python -m build
       - run: python -m twine check dist/*
-      - run: sha256sum dist/* > dist/SHA256SUMS
+      - name: Write portable checksums
+        working-directory: dist
+        run: sha256sum *.whl *.tar.gz > SHA256SUMS
       - name: Attach distributions and checksums
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

The published `SHA256SUMS` records `dist/` path prefixes, but GitHub Release assets download into the current directory. A standard `shasum -a 256 -c SHA256SUMS` therefore cannot open the files.

## Change

Generate checksums from inside `dist/` so each entry contains only the downloadable asset filename.

## Evidence

- fresh wheel and source distribution build passes
- generated checksum entries use flat filenames
- `shasum -a 256 -c SHA256SUMS` passes
- release workflow passes actionlint

No runtime, artifact schema, policy schema, or package compatibility changes.