### PR TITLE
chore: prepare verified v0.3.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      - run: python -m pip install -e ".[rag,dev]"
+      - run: python -m pip install -e ".[rag,dashboard,dev]"
       - run: ruff check .
       - run: mypy src/evalforge
       - run: pytest --cov=evalforge --cov-report=term-missing --cov-fail-under=85
@@ -36,8 +36,26 @@ jobs:
         run: |
           EVALFORGE_DATABASE_URL=sqlite:///./ci_evalforge.db evalforge seed
           EVALFORGE_DATABASE_URL=sqlite:///./ci_evalforge.db evalforge check hybrid_top3 --report-dir artifacts
-      - if: matrix.python-version == '3.12'
-        run: python -m build
+      - name: Validate release-gate reports
+        if: matrix.python-version == '3.12'
+        run: |
+          python -m json.tool artifacts/evalforge-report.json >/dev/null
+          python -m json.tool artifacts/evalforge.sarif >/dev/null
+          python -c "from xml.etree import ElementTree; ElementTree.parse('artifacts/evalforge-junit.xml')"
+      - name: Build and check distributions
+        if: matrix.python-version == '3.12'
+        run: make release-check
+      - name: Test the built wheel in a fresh environment
+        if: matrix.python-version == '3.12'
+        run: |
+          python -m venv "$RUNNER_TEMP/evalforge-wheel"
+          "$RUNNER_TEMP/evalforge-wheel/bin/python" -m pip install dist/*.whl
+          "$RUNNER_TEMP/evalforge-wheel/bin/evalforge" gate examples/candidate_summary.json \
+            --policy examples/quality_policy.json \
+            --baseline examples/baseline_summary.json \
+            --json "$RUNNER_TEMP/evalforge-wheel/report.json" \
+            --junit "$RUNNER_TEMP/evalforge-wheel/junit.xml" \
+            --sarif "$RUNNER_TEMP/evalforge-wheel/report.sarif"
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,14 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   distributions:
     if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -19,12 +20,20 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - run: python -m pip install build twine
-      - run: python -m build
-      - run: python -m twine check dist/*
+      - name: Verify checked-out tag target
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          release_tag_commit=$(git rev-list -n 1 "$RELEASE_TAG")
+          checked_out_commit=$(git rev-parse HEAD)
+          test "$release_tag_commit" = "$checked_out_commit"
+      - run: python -m pip install ".[dev]"
+      - run: make release-check
       - name: Write portable checksums
         working-directory: dist
-        run: sha256sum *.whl *.tar.gz > SHA256SUMS
+        run: |
+          sha256sum *.whl *.tar.gz > SHA256SUMS
+          sha256sum --check SHA256SUMS
       - name: Attach distributions and checksums
         env:
           GH_TOKEN: ${{ github.token }}

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,16 @@
+# Adopters
+
+EvalForge records downstream use only when it can be verified publicly and the project's maintainer has agreed to be listed.
+
+There are no confirmed downstream adopters yet. GitHub stars and automated trend indexes show early interest, but they are not evidence of an integration or production use.
+
+## Add your project
+
+Open an issue or pull request with:
+
+- the public repository and a link to the EvalForge Action or artifact-schema integration;
+- the EvalForge version or commit in use;
+- a short description of what the quality gate protects; and
+- confirmation that the project may be named here.
+
+The maintainers verify the link before adding an entry. Private users may share feedback without being listed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes are documented here. The project follows semantic versioning while the artifact and policy formats carry independent schema versions.
 
-## [0.3.0] - 2026-08-30
+## [0.3.0] - 2026-08-31
 
 ### Added
 
@@ -12,7 +12,7 @@ All notable changes are documented here. The project follows semantic versioning
 - An end-to-end `evalforge check` command that runs the built-in RAG evaluator and emits portable JSON, JUnit, and SARIF evidence.
 - A seeded RAG release gate in GitHub Actions.
 - An engineering case study and resume-ready project narrative.
-- An expanded 39-test suite with 87.68% measured line coverage.
+- An expanded test suite with an enforced 85% branch-coverage floor.
 
 ## [0.2.1] - 2026-08-30
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If EvalForge supports your research or engineering work, please cite the software.
 title: EvalForge
 type: software
-version: 0.2.1
-date-released: 2026-08-30
+version: 0.3.0
+date-released: 2026-08-31
 license: MIT
 repository-code: https://github.com/jsdhwfmax/EvalForge
 url: https://github.com/jsdhwfmax/EvalForge

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint gate-demo package run dashboard demo docker
+.PHONY: install test lint gate-demo package release-check run dashboard demo docker
 
 PYTHON ?= python3
 
@@ -6,7 +6,7 @@ install:
 	$(PYTHON) -m pip install -e ".[rag,dashboard,dev]"
 
 test:
-	pytest --cov=evalforge --cov-report=term-missing --cov-fail-under=80
+	pytest --cov=evalforge --cov-report=term-missing --cov-fail-under=85
 
 lint:
 	ruff check .
@@ -23,6 +23,9 @@ gate-demo:
 
 package:
 	$(PYTHON) -m build
+
+release-check: package
+	$(PYTHON) -m twine check dist/*.whl dist/*.tar.gz
 
 run:
 	uvicorn evalforge.api:app --reload

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 [![CI](https://github.com/jsdhwfmax/EvalForge/actions/workflows/ci.yml/badge.svg)](https://github.com/jsdhwfmax/EvalForge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-0B7285.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.9%2B-3776AB.svg)](https://www.python.org/)
-[![Tests](https://img.shields.io/badge/tests-39%20passed-12B76A.svg)](tests)
-[![Coverage](https://img.shields.io/badge/coverage-87.68%25-7F56D9.svg)](tests)
 [![GitHub stars](https://img.shields.io/github/stars/jsdhwfmax/EvalForge?style=flat)](https://github.com/jsdhwfmax/EvalForge/stargazers)
 
 EvalForge turns AI evaluation results into reviewable release evidence. It includes a transparent RAG evaluator, a vendor-neutral JSON artifact, and policy-as-code gates that emit JSON, JUnit, and SARIF for existing CI systems.
@@ -131,7 +129,7 @@ The command prints the measured summary, writes a portable evaluation artifact p
 ### GitHub Action
 
 ```yaml
-- uses: jsdhwfmax/EvalForge@v0.2.1
+- uses: jsdhwfmax/EvalForge@v0.3.0
   with:
     candidate: build/candidate.json
     baseline: build/baseline.json
@@ -139,6 +137,8 @@ The command prints the measured summary, writes a portable evaluation artifact p
 ```
 
 The Action writes `evalforge-report.json`, `evalforge-junit.xml`, and `evalforge.sarif` by default. Upload them with the standard reporting actions already used by your repository. Pin a full commit SHA where your supply-chain policy requires immutable Actions.
+
+Using EvalForge in another public repository? Please open an issue or pull request to add it to [ADOPTERS.md](ADOPTERS.md). Projects are listed only with a maintainer's consent and a public, verifiable integration link.
 
 The base `evalforge-ci` distribution installs only the gate dependencies. The built-in RAG API is available through the `rag` extra; the UI uses the `dashboard` extra. This keeps the reusable gate small for downstream CI jobs.
 

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -27,9 +27,11 @@ Project importance must be demonstrated, not declared. Maintainers will report o
 - documented integrations with evaluation and CI tools;
 - security reports and time to remediation.
 
-### Dated adoption snapshot
+### Dated adoption snapshots
 
 From its public launch on 2026-08-24 through 2026-08-30, the repository received 41 GitHub stars. That is a verifiable signal of early interest, not proof of production use or broad adoption. As of this snapshot, confirmed downstream integrations, external issues, external pull requests, external contributors, and forks remain at zero. The project will keep these categories separate rather than converting attention into an unsupported infrastructure claim.
+
+On 2026-08-31, the repository reached 48 GitHub stars. Public GitHub data still showed zero forks and zero external contributors, and an exact global code search found no downstream repository using `uses: jsdhwfmax/EvalForge`. These numbers continue to measure early interest rather than adoption; confirmed users will be recorded separately in [`ADOPTERS.md`](../ADOPTERS.md) with consent and a public integration link.
 
 ## Twelve-month success criteria
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -3,11 +3,13 @@
 EvalForge releases should leave public, reproducible evidence that the tagged source is usable.
 
 1. Confirm the changelog, package version, `evalforge.__version__`, README Action tag, and `CITATION.cff` agree.
-2. Run `make lint`, `make test`, `make gate-demo`, and `python -m build` from a clean checkout.
+2. Run `make lint`, `make test`, `make gate-demo`, and `make release-check` from a clean checkout.
 3. Install the built wheel in a fresh environment and run the committed quality-gate example.
 4. Confirm main-branch CI and all dependency update checks are green.
 5. Create a signed or GitHub-verified tag and publish release notes that state compatibility and known limitations.
 6. Verify the release workflow attached the wheel, source distribution, and `SHA256SUMS` file.
 7. Record only verifiable adoption, compatibility, and security evidence; never infer production use from stars alone.
+
+The release CI must also parse the generated JSON, JUnit, and SARIF reports and install the built wheel in a fresh environment before a tag is published.
 
 PyPI publication is a separate step. Do not claim that `evalforge-ci` is available from PyPI until the project page and published files are publicly verifiable.

--- a/docs/superpowers/plans/2026-08-31-v0.3-release-and-oss-readiness.md
+++ b/docs/superpowers/plans/2026-08-31-v0.3-release-and-oss-readiness.md
@@ -1,0 +1,241 @@
+# EvalForge v0.3 release and OSS readiness implementation plan
+
+**Goal:** 把当前已经写入 `main` 的 0.3.0 功能整理成可验证、可安装、可维护的正式版本，同时补强 Codex for Open Source 申请中最重要的“项目真实价值、持续维护能力与生态采用证据”。
+
+**Approach:** 先完成一个范围受控的 v0.3.0 发布 PR，解决版本元数据、工具链与发布自动化的确定性问题；再通过 PyPI、主分支规则、下游采用记录和首个真实适配器逐步建立生态证据。所有采用数字都保留日期与来源，Stars 只作为早期兴趣信号，不写成生产采用。申请是否批准由 OpenAI 审核，本计划不把 48 Stars 或任一单项指标表述成保证。
+
+**Affected areas:** `README.md`、`CHANGELOG.md`、`CITATION.cff`、`pyproject.toml`、`Makefile`、`.github/workflows/`、`docs/ECOSYSTEM.md`、`docs/RELEASE_CHECKLIST.md`、测试与发布设置；发布后更新仓库外的申请材料。
+
+## 审计基线（2026-08-31）
+
+- 公共仓库已有 48 Stars、0 forks；公开搜索未发现其他仓库使用 `uses: jsdhwfmax/EvalForge`，因此目前不能声称存在真实下游集成。
+- `origin/main` 为 `3a1ee8d`，最新主分支 CI 成功；39 项测试通过，本地 Python 3.13 审计覆盖率为 87.97%，高于 CI 的 85% 门槛。
+- `pyproject.toml` 和 `evalforge.__version__` 已是 0.3.0，`CHANGELOG.md` 也已有 0.3.0 条目，但 `CITATION.cff` 与 README 的 Action 示例仍为 0.2.1；GitHub 尚无 v0.3.0 tag/release。
+- 从干净的 `origin/main` 构建出的 0.3.0 wheel 与 sdist 均通过 `twine check`。
+- `evalforge-ci` 的 PyPI JSON 端点返回 404，尚未公开发布。
+- 当前开发依赖允许 mypy 2.x；实测 mypy 2.3.1 不再接受 `python_version = "3.9"`，与项目声明的 Python 3.9 支持冲突。
+- 当前唯一开放项是 Dependabot PR #7（Plotly `<7` 更新到 `<8`）。
+- 审计开始时本地 checkout `codex/v0.2.1-checksum-fix` 相对 `origin/main` 为 ahead 1 / behind 4；实施必须从最新 `origin/main` 新建分支，不能直接在旧分支继续发布工作。
+
+## Phase A：发布 v0.3.0
+
+### Task 1：建立新发布分支并处理依赖 PR
+
+**Files:**
+- Review: `.github/workflows/ci.yml`
+- Review: `pyproject.toml`
+- Review: `dashboard/app.py`
+- Test: dashboard smoke test or the existing dashboard-related test surface
+
+**Steps:**
+1. Fetch `origin` and create a fresh branch such as `codex/v0.3.0-release` from `origin/main`; confirm only intended release changes appear in `git diff origin/main...HEAD`.
+2. Inspect Dependabot PR #7's exact diff and successful checks. Run a minimal dashboard import/smoke test with Plotly 7 before merging it.
+3. If Plotly 7 passes, merge PR #7 before cutting v0.3.0 and retain `plotly>=5.22,<8`; otherwise close it with the reproducible incompatibility and keep `<7`.
+4. Rebase or recreate the release branch from the resulting `main` so the release commit includes exactly the dependency decision that CI verified.
+
+**Verification:**
+- `git status --short --branch`
+- `git diff --check origin/main...HEAD`
+- `python -c "import plotly; import streamlit; print(plotly.__version__)"`
+- Required PR checks are green before merge.
+
+### Task 2：统一版本元数据，并用测试阻止再次漂移
+
+**Files:**
+- Modify: `CITATION.cff`
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Verify: `pyproject.toml`
+- Verify: `src/evalforge/__init__.py`
+- Create: `tests/test_release_metadata.py`
+
+**Steps:**
+1. Keep the release version at 0.3.0; do not bump to 0.3.1 or 0.4.0，因为当前问题是 0.3.0 尚未完成发布，不是缺少另一个版本号。
+2. Set `CITATION.cff` to 0.3.0 and use the actual release date rather than the date the changelog draft was written.
+3. Change the README composite Action example from `@v0.2.1` to immutable `@v0.3.0`.
+4. Keep the README's alpha status transparent. Remove the manually maintained test-count and coverage badges, or replace them only with CI-produced dynamic badges; do not keep numbers that can silently drift from CI.
+5. Reconcile the changelog's test/coverage sentence with the authoritative release CI result, not a local Python version's measurement.
+6. Add a metadata test that reads the project version, imports `evalforge.__version__`, extracts the CFF version, and verifies the README Action tag. The test must fail if these four values differ.
+
+**Verification:**
+- `pytest tests/test_release_metadata.py -q`
+- `rg -n '0\.2\.1|0\.3\.0|coverage-|tests-' README.md CITATION.cff CHANGELOG.md pyproject.toml src/evalforge/__init__.py`
+- `git diff --check`
+
+### Task 3：固定 Python 3.9 兼容的开发工具链
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `Makefile`
+- Modify: `docs/RELEASE_CHECKLIST.md`
+
+**Steps:**
+1. Change the mypy development range from `<3` to `<2`, preserving the Python 3.9 type target while avoiding the mypy 2.x incompatibility observed in the audit.
+2. Add `twine>=5,<7` to the development extra so the documented release check works from `.[dev]`, not only inside the GitHub Release workflow.
+3. Align `make test` with CI's `--cov-fail-under=85`; one project must have one coverage gate.
+4. Add a `release-check` Make target that builds wheel/sdist and runs `python -m twine check` on both artifacts.
+5. Keep runtime tests on Python 3.9 and 3.12. Run lint/type checking once in the maintained tooling environment if duplicate matrix execution adds no compatibility coverage, but retain a Python 3.9 runtime/import test.
+6. Make the CI build step call the same `make release-check` path used by maintainers.
+
+**Verification:**
+- `python -m pip install -e '.[rag,dashboard,dev]'`
+- `make lint`
+- `make test`
+- `make gate-demo`
+- `make release-check`
+- CI logs contain no unsupported-Python warning from mypy.
+
+### Task 4：把 v0.3.0 的核心承诺变成端到端发布门禁
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/workflows/release.yml`
+- Modify: `docs/RELEASE_CHECKLIST.md`
+- Test: `tests/test_cli.py`
+- Test: `tests/test_artifacts_gates.py`
+
+**Steps:**
+1. Preserve the seeded RAG release gate and assert that its JSON、JUnit 与 SARIF outputs are all created and parseable, rather than only relying on process exit 0.
+2. Install the just-built wheel into a fresh temporary virtual environment and run the committed gate example through the installed `evalforge` executable. This catches missing package data and entry-point errors that editable installs hide.
+3. In the release workflow, verify that the checked-out commit equals the release tag target before building.
+4. Generate `SHA256SUMS`, verify it locally in the workflow, then attach wheel、sdist 与 checksum file. Do not publish or advertise an artifact until all three are visible.
+5. Pin every third-party GitHub Action to a full reviewed commit SHA and keep the human-readable release tag in a trailing comment.
+
+**Verification:**
+- `python -m json.tool build/evalforge-report.json >/dev/null`
+- Parse the generated JUnit XML and SARIF JSON in tests.
+- Create a temporary venv, install `dist/evalforge_ci-0.3.0-py3-none-any.whl`, and run `evalforge gate examples/candidate_summary.json --policy examples/quality_policy.json --baseline examples/baseline_summary.json`.
+- `sha256sum --check dist/SHA256SUMS` on Linux release runners.
+
+### Task 5：更新诚实、可复核的生态证据
+
+**Files:**
+- Modify: `docs/ECOSYSTEM.md`
+- Create: `ADOPTERS.md`
+- Modify: `README.md`
+- Modify after release: `/Users/z./Documents/Codex/2026-08-24/wo/outputs/EvalForge-Codex-for-OSS-申请与推广材料.md`
+
+**Steps:**
+1. Preserve the 2026-08-30 snapshot and append a new 2026-08-31 snapshot: 48 Stars、0 forks、0 confirmed downstream Action users、0 external contributors. This shows momentum without rewriting history.
+2. Create `ADOPTERS.md` with contribution instructions and evidence rules. Begin with “暂无经维护者确认的下游采用”，不要把 trending feed、Star 或自动索引当成 adopter。
+3. Add a short README invitation asking real users to open an issue or PR to record their integration, with consent before listing organization names.
+4. After the release is public, update the application/promotional material with v0.3.0、the current dated Star count、green CI and verifiable release/PyPI links. Keep the zero-adoption facts explicit until they change.
+
+**Verification:**
+- Global GitHub code search for the exact `uses: jsdhwfmax/EvalForge` string excluding the source repository.
+- Check repository contributors, forks, releases and open PRs directly on GitHub.
+- Review every numerical claim against a dated public URL before publishing application text.
+
+### Task 6：合并发布 PR并创建 v0.3.0
+
+**Files:**
+- Final review: all Phase A files
+- GitHub setting: release/tag, not a repository source file
+
+**Steps:**
+1. Open one focused release PR from the fresh branch. The PR body must list version consistency, Python support, artifact verification and ecosystem evidence separately.
+2. Require all CI jobs to pass and review the final `origin/main...HEAD` diff for unrelated files.
+3. Merge the PR, verify the merge commit's main-branch CI, then create a GitHub-verified `v0.3.0` tag at that exact commit.
+4. Publish a normal pre-1.0 GitHub Release with “Alpha” stated in the notes, rather than marking tested assets as an informal draft. Include compatibility (`Python >=3.9`), schema versions, migration notes and known limitations.
+5. Download the public assets without repository credentials, validate `SHA256SUMS`, install the public wheel and rerun the gate example.
+6. Only after public verification, change the project's public “latest version” language and send the updated link to prospective users.
+
+**Verification:**
+- `git ls-remote --tags origin refs/tags/v0.3.0`
+- Public GitHub Release contains exactly the expected wheel、sdist and `SHA256SUMS`.
+- A fresh environment can install the downloaded wheel and run `evalforge --help` plus the gate example.
+
+## Phase B：申请与生态强化（v0.3.1 目标）
+
+### Task 7：启用 PyPI Trusted Publishing
+
+**Files:**
+- Create: `.github/workflows/publish-pypi.yml` or extend `.github/workflows/release.yml`
+- Modify: `README.md`
+- Modify: `docs/RELEASE_CHECKLIST.md`
+- GitHub setting: protected `pypi` environment
+- PyPI setting: pending Trusted Publisher for `evalforge-ci`
+
+**Steps:**
+1. Configure PyPI Trusted Publishing for repository `jsdhwfmax/EvalForge`, the exact workflow filename and the protected `pypi` environment; do not create or store an API token.
+2. Grant `id-token: write` only to the publish job and keep other jobs at read-only permissions.
+3. Use the official PyPI publish Action pinned to a reviewed full commit SHA. Publish only artifacts produced and verified by the release build.
+4. Publish 0.3.0 only if the name remains available and the GitHub release artifact is final. Because PyPI files are immutable, stop rather than overwrite if any public 0.3.0 distribution already exists.
+5. After publication, verify the JSON API and install `evalforge-ci==0.3.0` in a fresh environment before adding the PyPI badge/install command to README.
+
+**Verification:**
+- `curl --fail https://pypi.org/pypi/evalforge-ci/0.3.0/json`
+- `python -m pip install --no-cache-dir 'evalforge-ci==0.3.0'`
+- `evalforge --version` or `python -c 'import evalforge; print(evalforge.__version__)'` prints 0.3.0.
+
+### Task 8：保护 main 并建立基础安全扫描
+
+**Files:**
+- Create: `.github/workflows/codeql.yml`
+- Modify: `SECURITY.md` only if reporting paths change
+- GitHub setting: repository ruleset for `main`
+
+**Steps:**
+1. Add CodeQL analysis for Python on pull requests, pushes to `main`, and a weekly schedule; pin CodeQL Actions to full SHAs and grant only required `security-events: write` permission.
+2. Create a `main` ruleset requiring pull requests and the stable CI checks (`test (3.9)`, `test (3.12)`, `docker`, plus the release-audit job if introduced), while blocking force pushes and branch deletion.
+3. Keep a documented maintainer bypass for emergency security fixes, with all bypasses followed by a normal PR and CI run.
+4. Test the ruleset with a disposable documentation PR before relying on it for release governance.
+
+**Verification:**
+- GitHub ruleset API/UI shows the ruleset active for `main`.
+- A test PR cannot merge with a required check failing.
+- CodeQL's initial scan completes and the workflow does not request broad write permissions.
+
+### Task 9：用真实上游 fixture 落地首个 evaluator adapter
+
+**Files:**
+- Create: `src/evalforge/adapters/__init__.py`
+- Create: `src/evalforge/adapters/promptfoo.py`
+- Create: `tests/fixtures/promptfoo/` with a small license-compatible upstream-format fixture
+- Create: `tests/test_promptfoo_adapter.py`
+- Modify: `src/evalforge/cli.py`
+- Modify: `docs/INTEROPERABILITY.md`
+- Modify: `README.md`
+
+**Steps:**
+1. Start with promptfoo because EvalForge's CI-gate role is complementary to promptfoo's evaluation output. Before coding, verify promptfoo's current official output schema and fixture license at the exact upstream version used by the test.
+2. Convert only documented aggregate metrics and provenance into EvalForge artifact schema 1.0. Reject unknown/non-finite values and preserve the source tool/version in metadata.
+3. Add an explicit CLI import command; do not silently guess formats from arbitrary JSON.
+4. Test a valid fixture、unknown metric、missing provenance、non-finite value and a forward-compatible extra field.
+5. Document the supported promptfoo version range and the mapping table. Do not claim a general integration with Ragas or DeepEval until each has its own upstream-backed fixture and compatibility tests.
+
+**Verification:**
+- `pytest tests/test_promptfoo_adapter.py -q`
+- `evalforge import promptfoo tests/fixtures/promptfoo/results.json --output build/promptfoo-evalforge.json`
+- Validate the output against `schemas/evalforge-artifact.schema.json` and run it through the existing policy gate.
+
+### Task 10：提交 Codex for Open Source 申请
+
+**Files:**
+- Modify: `/Users/z./Documents/Codex/2026-08-24/wo/outputs/EvalForge-Codex-for-OSS-申请与推广材料.md`
+- External action: OpenAI application form
+
+**Steps:**
+1. Apply as the core maintainer of a public project and explain the ecosystem role narrowly: evaluator-neutral release evidence between evaluation frameworks and existing CI systems.
+2. Link the public repository、v0.3.0 release、CI、security policy、governance、ecosystem evidence and PyPI page if publication is complete.
+3. State current adoption exactly: early interest measured by dated Stars, but no confirmed production adopters unless `ADOPTERS.md` has independently verified entries by application day.
+4. Explain concrete uses for program benefits: PR review and maintainer automation, release workflow maintenance, adapter/schema compatibility work, and security review. Do not imply entitlement or guaranteed acceptance.
+5. Save a dated copy of the submitted answers and public evidence so future updates remain auditable.
+
+**Verification:**
+- Every link works in a signed-out browser.
+- Repository/release/PyPI version numbers agree.
+- No claim depends on private analytics or unsupported inference.
+
+## Release decision gate
+
+Proceed with v0.3.0 only when Tasks 1–5 are complete, the release PR and resulting `main` CI are green, metadata is consistent, and a fresh wheel install passes the committed gate example. PyPI、branch rules、CodeQL and the promptfoo adapter strengthen the application but should not delay a healthy GitHub v0.3.0 release unless they uncover a correctness or supply-chain problem.
+
+## Primary references
+
+- OpenAI Codex for Open Source: https://learn.chatgpt.com/community/codex-for-oss
+- Repository: https://github.com/jsdhwfmax/EvalForge
+- Latest audited main CI run: https://github.com/jsdhwfmax/EvalForge/actions/runs/33307765462
+- Open Dependabot PR #7: https://github.com/jsdhwfmax/EvalForge/pull/7
+- PyPI project endpoint to verify after publishing: https://pypi.org/project/evalforge-ci/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ rag = [
   "sqlalchemy>=2.0,<3",
   "uvicorn[standard]>=0.30,<1",
 ]
-dashboard = ["pandas>=2.0,<3", "plotly>=5.22,<7", "streamlit>=1.37,<2"]
+dashboard = ["pandas>=2.0,<3", "plotly>=5.22,<8", "streamlit>=1.37,<2"]
 dev = [
   "build>=1.2,<2",
   "coverage[toml]>=7.6,<8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,11 @@ dev = [
   "build>=1.2,<2",
   "coverage[toml]>=7.6,<8",
   "jsonschema>=4.23,<5",
-  "mypy>=1.11,<3",
+  "mypy>=1.11,<2",
   "pytest>=8.2,<10",
   "pytest-cov>=5,<8",
   "ruff>=0.6,<1",
+  "twine>=5,<7",
 ]
 
 [project.scripts]
@@ -80,6 +81,7 @@ ignore = ["B008"]
 
 [tool.mypy]
 python_version = "3.9"
+cache_dir = ".mypy_cache/1.x"
 ignore_missing_imports = true
 follow_imports = "skip"
 warn_unused_ignores = true

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+from xml.etree import ElementTree
 
 from test_api import load_demo
 from typer.testing import CliRunner
@@ -36,8 +37,10 @@ def test_check_command_writes_ci_reports(client, tmp_path):
     artifact = json.loads((tmp_path / "evaluation-artifact.json").read_text())
     assert report["passed"] is True
     assert artifact["metadata"]["dataset_fingerprint"]
-    assert (tmp_path / "evalforge-junit.xml").exists()
-    assert (tmp_path / "evalforge.sarif").exists()
+    junit = ElementTree.parse(tmp_path / "evalforge-junit.xml").getroot()
+    sarif = json.loads((tmp_path / "evalforge.sarif").read_text())
+    assert junit.tag == "testsuite"
+    assert sarif["version"] == "2.1.0"
 
 
 def test_gate_command_returns_nonzero_for_regression(client):

--- a/tests/test_dashboard_compat.py
+++ b/tests/test_dashboard_compat.py
@@ -1,0 +1,26 @@
+import pandas as pd
+import plotly
+import plotly.express as px
+
+
+def test_supported_plotly_builds_dashboard_chart():
+    frame = pd.DataFrame(
+        {
+            "Metric": ["Recall@K", "Correctness"],
+            "Score": [0.8, 0.9],
+            "Configuration": ["baseline", "candidate"],
+        }
+    )
+
+    figure = px.bar(
+        frame,
+        x="Metric",
+        y="Score",
+        color="Configuration",
+        barmode="group",
+        range_y=[0, 1],
+    )
+    figure.update_layout(plot_bgcolor="white", paper_bgcolor="white")
+
+    assert plotly.__version__.split(".", 1)[0] in {"5", "6", "7"}
+    assert len(figure.data) == 2

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,31 @@
+import re
+from pathlib import Path
+
+from evalforge import __version__
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _required_match(path, pattern):
+    match = re.search(pattern, path.read_text(encoding="utf-8"), flags=re.MULTILINE | re.DOTALL)
+    assert match is not None, "Missing release metadata in %s" % path
+    return match.group(1)
+
+
+def test_release_versions_and_dates_agree():
+    project_version = _required_match(
+        ROOT / "pyproject.toml", r"^\[project\]\s+.*?^version = \"([^\"]+)\""
+    )
+    citation_version = _required_match(ROOT / "CITATION.cff", r"^version:\s*([^\s]+)$")
+    action_version = _required_match(
+        ROOT / "README.md", r"uses:\s+jsdhwfmax/EvalForge@v([0-9]+\.[0-9]+\.[0-9]+)"
+    )
+    changelog_date = _required_match(
+        ROOT / "CHANGELOG.md", r"^## \[%s\] - ([0-9]{4}-[0-9]{2}-[0-9]{2})$" % __version__
+    )
+    citation_date = _required_match(
+        ROOT / "CITATION.cff", r"^date-released:\s*([0-9]{4}-[0-9]{2}-[0-9]{2})$"
+    )
+
+    assert {project_version, citation_version, action_version, __version__} == {__version__}
+    assert citation_date == changelog_date


### PR DESCRIPTION
## Problem

EvalForge's v0.3 functionality was already on main, but public release metadata still referenced v0.2.1, the development tool range allowed a mypy version that no longer accepts Python 3.9, and CI did not install and exercise the built wheel.

## Change

- align the changelog, citation metadata, package version, and reusable Action example on v0.3.0
- keep Python 3.9 support by constraining mypy to 1.x and add a reproducible release-check target
- verify Plotly 7 dashboard compatibility and include the already-green Dependabot update
- parse JSON, JUnit, and SARIF outputs and install the built wheel in a fresh CI environment
- add honest, dated ecosystem and adopter evidence plus the implementation plan

## Evidence

- [x] Tests added or updated
- [x] `make lint` passes
- [x] `make test` passes: 41 tests, 87.68% coverage
- [x] Documentation updated
- [x] Wheel and sdist pass `twine check`
- [x] Fresh wheel install completes the committed gate and produces parseable JSON, JUnit, and SARIF
- [x] Plotly 7.0 dashboard chart smoke test passes
- [x] Artifact and policy schemas remain at version 1; no metric semantics changed

## Security and data

This change does not alter prompt, model-output, credential, or user-dataset handling. Release workflow permissions are narrowed to the distribution job and third-party Actions remain pinned to full commit SHAs.

## Release

After this PR and the resulting main-branch CI pass, publish v0.3.0 from the merge commit and verify the public wheel, sdist, and SHA256SUMS assets.