### PR TITLE
feat: add promptfoo adapter and trusted release path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
         dependency-type: production
       python-development:
         dependency-type: development
+    # mypy 2.x and Twine 7.x require Python >=3.10. Keep development tooling
+    # installable in the maintained Python 3.9 CI job.
+    ignore:
+      - dependency-name: mypy
+        update-types: [version-update:semver-major]
+      - dependency-name: twine
+        update-types: [version-update:semver-major]
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,27 @@ jobs:
         run: |
           EVALFORGE_DATABASE_URL=sqlite:///./ci_evalforge.db evalforge seed
           EVALFORGE_DATABASE_URL=sqlite:///./ci_evalforge.db evalforge check hybrid_top3 --report-dir artifacts
+      - name: Run the promptfoo interoperability gate
+        if: matrix.python-version == '3.12'
+        run: |
+          evalforge import promptfoo tests/fixtures/promptfoo/results-v3.json \
+            --output artifacts/promptfoo-artifact.json \
+            --source-revision "$GITHUB_SHA"
+          evalforge gate artifacts/promptfoo-artifact.json \
+            --policy examples/promptfoo_policy.json \
+            --json artifacts/promptfoo-report.json \
+            --junit artifacts/promptfoo-junit.xml \
+            --sarif artifacts/promptfoo.sarif
       - name: Validate release-gate reports
         if: matrix.python-version == '3.12'
         run: |
           python -m json.tool artifacts/evalforge-report.json >/dev/null
           python -m json.tool artifacts/evalforge.sarif >/dev/null
+          python -m json.tool artifacts/promptfoo-artifact.json >/dev/null
+          python -m json.tool artifacts/promptfoo-report.json >/dev/null
+          python -m json.tool artifacts/promptfoo.sarif >/dev/null
           python -c "from xml.etree import ElementTree; ElementTree.parse('artifacts/evalforge-junit.xml')"
+          python -c "from xml.etree import ElementTree; ElementTree.parse('artifacts/promptfoo-junit.xml')"
       - name: Build and check distributions
         if: matrix.python-version == '3.12'
         run: make release-check

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: python
+          build-mode: none
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: /language:python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ on:
 permissions: {}
 
 jobs:
-  distributions:
-    if: startsWith(github.event.release.tag_name, 'v')
+  build:
+    if: startsWith(github.event.release.tag_name, 'v') && github.event.release.prerelease == false
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -27,14 +27,67 @@ jobs:
           release_tag_commit=$(git rev-list -n 1 "$RELEASE_TAG")
           checked_out_commit=$(git rev-parse HEAD)
           test "$release_tag_commit" = "$checked_out_commit"
+          package_version=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          test "$RELEASE_TAG" = "v$package_version"
       - run: python -m pip install ".[dev]"
       - run: make release-check
-      - name: Write portable checksums
-        working-directory: dist
+      - name: Assemble verified release files
         run: |
-          sha256sum *.whl *.tar.gz > SHA256SUMS
-          sha256sum --check SHA256SUMS
+          mkdir -p release-files/packages
+          cp dist/*.whl dist/*.tar.gz release-files/packages/
+          sha256sum release-files/packages/* | sed 's#release-files/packages/##' > release-files/SHA256SUMS
+          cd release-files/packages
+          sha256sum --check ../SHA256SUMS
+      - name: Store verified distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: verified-release-files
+          path: release-files/
+          if-no-files-found: error
+          retention-days: 7
+
+  github-release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Retrieve verified release files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: verified-release-files
+          path: release-files
+      - name: Verify downloaded distributions
+        working-directory: release-files/packages
+        run: sha256sum --check ../SHA256SUMS
       - name: Attach distributions and checksums
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            release-files/packages/* release-files/SHA256SUMS --clobber \
+            --repo "${{ github.repository }}"
+
+  pypi-publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/evalforge-ci
+    permissions:
+      actions: read
+      id-token: write
+    steps:
+      - name: Retrieve verified distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: verified-release-files
+          path: release-files
+      - name: Verify downloaded distributions
+        working-directory: release-files/packages
+        run: sha256sum --check ../SHA256SUMS
+      - name: Publish distributions with OIDC
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: release-files/packages/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes are documented here. The project follows semantic versioning while the artifact and policy formats carry independent schema versions.
 
+## [0.3.1] - 2026-08-31
+
+### Added
+
+- An explicit promptfoo JSON results-schema-v3 adapter that emits sanitized aggregate evidence and preserves producer provenance.
+- Upstream-format synthetic promptfoo fixtures and compatibility tests covering unknown fields, missing provenance, non-finite evidence, inconsistent counts, and the CLI import path.
+- CodeQL analysis for Python pull requests, main-branch pushes, and scheduled scans with minimal permissions.
+- PyPI Trusted Publishing through GitHub OIDC, with the official publish Action pinned to a reviewed commit.
+- Workflow invariants that reject floating third-party Action references and keep the OIDC permission scoped to the publish job.
+
+### Changed
+
+- Build release distributions once, verify them with Twine and SHA-256, then reuse the same workflow artifact for GitHub Release assets and PyPI publication.
+- Document the promptfoo metric mapping, source-version boundary, privacy exclusions, and first-release Trusted Publisher checklist.
+- Keep Dependabot from proposing mypy 2.x or Twine 7.x while the project maintains Python 3.9 compatibility.
+- Include conformance fixtures, examples, workflow definitions, and release metadata in the source distribution so its bundled test suite is self-contained.
+
 ## [0.3.0] - 2026-08-31
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If EvalForge supports your research or engineering work, please cite the software.
 title: EvalForge
 type: software
-version: 0.3.0
+version: 0.3.1
 date-released: 2026-08-31
 license: MIT
 repository-code: https://github.com/jsdhwfmax/EvalForge

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,11 @@
 include LICENSE
 include README.md
+include *.md
+include CITATION.cff
+include Makefile
+include action.yml
+recursive-include .github *.yml
+recursive-include docs *.md *.svg
+recursive-include examples *.json
 recursive-include schemas *.json
+recursive-include tests *.py *.json *.md

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 EvalForge turns AI evaluation results into reviewable release evidence. It includes a transparent RAG evaluator, a vendor-neutral JSON artifact, and policy-as-code gates that emit JSON, JUnit, and SARIF for existing CI systems.
 
-> Status: v0.3 alpha. The gate and offline evaluator are usable today; artifact schema 1.0 is intentionally small while interoperability feedback is collected.
+> Status: v0.3.1 alpha. The gate and offline evaluator are usable today; artifact schema 1.0 is intentionally small while interoperability feedback is collected.
 
 ## Why EvalForge?
 
@@ -32,6 +32,7 @@ Read the engineering narrative in the [case study](docs/CASE_STUDY.md) or use th
 | Capability | Included |
 |---|---|
 | Portable evidence | Versioned, evaluator-neutral JSON artifact and JSON Schemas |
+| Evaluator adapters | Explicit promptfoo JSON v3 import with sanitized aggregate evidence |
 | Policy gates | Absolute thresholds, baseline deltas, errors and advisory warnings |
 | CI reports | Stable exit codes plus JSON, JUnit XML, and SARIF 2.1.0 |
 | GitHub integration | Reusable composite Action with no hosted EvalForge account |
@@ -76,6 +77,26 @@ The candidate can also be any flat numeric summary:
 ```
 
 See the [portable artifact and policy specification](docs/INTEROPERABILITY.md).
+
+### Import promptfoo evidence
+
+Convert a promptfoo JSON output file into the same small artifact used by the
+gate, without copying prompts, responses, configuration, or traces:
+
+```bash
+promptfoo eval --output build/promptfoo-results.json
+evalforge import promptfoo build/promptfoo-results.json \
+  --output build/evalforge-artifact.json \
+  --source-revision "$GITHUB_SHA"
+
+evalforge gate build/evalforge-artifact.json \
+  --policy examples/promptfoo_policy.json
+```
+
+The adapter requires promptfoo results schema 3 and versioned producer
+metadata. It is verified against promptfoo 0.122.2; see the exact metric
+mapping and privacy boundary in the
+[interoperability specification](docs/INTEROPERABILITY.md#promptfoo-adapter).
 
 ### Docker (recommended)
 
@@ -129,7 +150,7 @@ The command prints the measured summary, writes a portable evaluation artifact p
 ### GitHub Action
 
 ```yaml
-- uses: jsdhwfmax/EvalForge@v0.3.0
+- uses: jsdhwfmax/EvalForge@v0.3.1
   with:
     candidate: build/candidate.json
     baseline: build/baseline.json

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -33,6 +33,8 @@ From its public launch on 2026-08-24 through 2026-08-30, the repository received
 
 On 2026-08-31, the repository reached 48 GitHub stars. Public GitHub data still showed zero forks and zero external contributors, and an exact global code search found no downstream repository using `uses: jsdhwfmax/EvalForge`. These numbers continue to measure early interest rather than adoption; confirmed users will be recorded separately in [`ADOPTERS.md`](../ADOPTERS.md) with consent and a public integration link.
 
+Later on 2026-08-31, the public repository reached 50 GitHub stars. It still had zero forks, zero external contributors, and zero confirmed downstream adopters; the only open pull request was an automated Dependabot update. The milestone is recorded as early interest only and does not change the project's adoption claims.
+
 ## Twelve-month success criteria
 
 1. Publish the uniquely named `evalforge-ci` distribution with reproducible releases.

--- a/docs/INTEROPERABILITY.md
+++ b/docs/INTEROPERABILITY.md
@@ -26,6 +26,46 @@ Metric names are intentionally open. Unknown metrics remain valid. A producer sh
 
 For incremental adoption, `evalforge gate` also accepts a flat JSON object of numeric metrics or an object with a `summary` field. EvalForge assigns known units and directions where possible and treats unknown values as neutral scores.
 
+## promptfoo adapter
+
+EvalForge has an explicit adapter for promptfoo JSON output files:
+
+```bash
+promptfoo eval --output build/promptfoo-results.json
+evalforge import promptfoo build/promptfoo-results.json \
+  --output build/evalforge-artifact.json \
+  --source-revision "$GITHUB_SHA"
+evalforge gate build/evalforge-artifact.json \
+  --policy examples/promptfoo_policy.json
+```
+
+The adapter accepts promptfoo `OutputFile` documents whose nested
+`results.version` is exactly `3`. The producer version is read from the
+required `metadata.promptfooVersion` field and preserved in the EvalForge
+artifact. Compatibility is verified against promptfoo `0.122.2` at upstream
+commit `9cd19241a0706fcf59dd609167f4218612fc4beb`; later producer versions remain
+acceptable only while they emit schema version 3.
+
+| promptfoo evidence | EvalForge metric | Mapping |
+|---|---|---|
+| `results.results[].success` | `promptfoo_pass_rate` | successful rows / all rows |
+| `results.results[].score` | `promptfoo_mean_score` | arithmetic mean |
+| `results.results[].latencyMs` | `latency_ms` | arithmetic mean in milliseconds |
+| `results.results[].cost` | `total_cost_usd` | sum, emitted only when every row reports cost |
+| `results.stats.tokenUsage.prompt` | `input_tokens` | aggregate prompt tokens |
+| `results.stats.tokenUsage.completion` | `output_tokens` | aggregate completion tokens |
+| number of result rows | `test_cases` | count |
+
+The declared success, failure, and error counts must agree with the result
+rows. Imported numeric evidence must be finite; latency, cost, tokens, and
+counts must also be non-negative.
+
+The adapter deliberately excludes prompt text, responses, variables, config,
+traces, arbitrary metadata, and unregistered `namedScores`. A promptfoo output
+may contain secrets or sensitive test data even after upstream sanitization,
+so the small aggregate artifact is the safer CI boundary. Add a reviewed
+mapping before treating a custom named score as stable release evidence.
+
 ## Gate policy v1
 
 The normative schema is [`schemas/gate-policy-v1.schema.json`](../schemas/gate-policy-v1.schema.json).
@@ -61,5 +101,6 @@ Schema version `1.0` follows these rules:
 4. Flat-summary compatibility is convenience input, not a replacement for the canonical artifact.
 5. Metric semantics belong to the producer; EvalForge evaluates the declared numeric evidence and never implies scientific validity.
 6. Delta comparisons require compatible units and directions; changing either requires a new baseline or an explicit migration.
+7. Evaluator adapters are opt-in commands with independently documented upstream schema boundaries; EvalForge never guesses an evaluator from arbitrary JSON.
 
 Open an issue before proposing a schema change. Include a real producer/consumer use case and a migration example.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -5,11 +5,14 @@ EvalForge releases should leave public, reproducible evidence that the tagged so
 1. Confirm the changelog, package version, `evalforge.__version__`, README Action tag, and `CITATION.cff` agree.
 2. Run `make lint`, `make test`, `make gate-demo`, and `make release-check` from a clean checkout.
 3. Install the built wheel in a fresh environment and run the committed quality-gate example.
-4. Confirm main-branch CI and all dependency update checks are green.
-5. Create a signed or GitHub-verified tag and publish release notes that state compatibility and known limitations.
-6. Verify the release workflow attached the wheel, source distribution, and `SHA256SUMS` file.
-7. Record only verifiable adoption, compatibility, and security evidence; never infer production use from stars alone.
+4. Confirm main-branch CI, CodeQL, and all dependency update checks are green.
+5. Before the first PyPI release, create a protected GitHub environment named `pypi` and configure a PyPI pending Trusted Publisher with owner `jsdhwfmax`, repository `EvalForge`, workflow `release.yml`, and environment `pypi`. Do not create an API token.
+6. Confirm `https://pypi.org/pypi/evalforge-ci/json` still returns 404 before registering the pending publisher. Stop if another owner has claimed the distribution name.
+7. Create a signed or GitHub-verified tag and publish release notes that state compatibility and known limitations.
+8. Verify the release workflow attached the wheel, source distribution, and `SHA256SUMS` file and completed the `pypi-publish` job through OIDC.
+9. Verify the exact release from an unauthenticated environment with `python -m pip install --no-cache-dir 'evalforge-ci==<version>'`, then run `evalforge --help` and the committed gate example.
+10. Record only verifiable adoption, compatibility, and security evidence; never infer production use from stars alone.
 
-The release CI must also parse the generated JSON, JUnit, and SARIF reports and install the built wheel in a fresh environment before a tag is published.
+The release CI must also parse the generated JSON, JUnit, and SARIF reports and install the built wheel in a fresh environment before a tag is published. The release workflow builds distributions once, stores them as a short-lived workflow artifact, and sends those same verified files to GitHub Releases and PyPI.
 
-PyPI publication is a separate step. Do not claim that `evalforge-ci` is available from PyPI until the project page and published files are publicly verifiable.
+PyPI publication uses Trusted Publishing. Only the `pypi-publish` job receives `id-token: write`; no PyPI password or API token belongs in repository secrets. Do not claim that `evalforge-ci` is available from PyPI until the project page and published files are publicly verifiable.

--- a/examples/promptfoo_policy.json
+++ b/examples/promptfoo_policy.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jsdhwfmax/EvalForge/main/schemas/gate-policy-v1.schema.json",
+  "version": 1,
+  "name": "promptfoo release gate",
+  "checks": [
+    {
+      "id": "promptfoo-pass-rate",
+      "metric": "promptfoo_pass_rate",
+      "op": "gte",
+      "value": 0.6,
+      "description": "At least 60% of promptfoo result rows must pass"
+    },
+    {
+      "id": "promptfoo-mean-score",
+      "metric": "promptfoo_mean_score",
+      "op": "gte",
+      "value": 0.6,
+      "description": "Mean promptfoo score must be at least 0.6"
+    },
+    {
+      "id": "promptfoo-latency",
+      "metric": "latency_ms",
+      "op": "lte",
+      "value": 250,
+      "description": "Mean row latency must be at most 250 ms"
+    },
+    {
+      "id": "promptfoo-cost",
+      "metric": "total_cost_usd",
+      "op": "lte",
+      "value": 0.01,
+      "description": "Total reported evaluation cost must be at most $0.01"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "evalforge-ci"
-version = "0.3.0"
+version = "0.3.1"
 description = "Portable evaluation evidence and policy gates for RAG and AI assistants"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/evalforge/__init__.py
+++ b/src/evalforge/__init__.py
@@ -1,3 +1,3 @@
 """EvalForge: portable evaluation evidence and quality gates for AI systems."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/src/evalforge/adapters/__init__.py
+++ b/src/evalforge/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Explicit adapters from evaluator-owned formats to EvalForge artifacts."""
+
+from evalforge.adapters.promptfoo import load_promptfoo_export, promptfoo_artifact_from_export
+
+__all__ = ["load_promptfoo_export", "promptfoo_artifact_from_export"]

--- a/src/evalforge/adapters/promptfoo.py
+++ b/src/evalforge/adapters/promptfoo.py
@@ -1,0 +1,201 @@
+"""Import the documented promptfoo JSON output format without copying raw content."""
+
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from evalforge.artifacts import EvaluationArtifact, artifact_from_summary
+
+PROMPTFOO_SCHEMA_VERSION = 3
+ADAPTER_MAPPING_VERSION = "1"
+_SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
+
+
+def _object(value: Any, path: str) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("promptfoo %s must be a JSON object" % path)
+    return value
+
+
+def _array(value: Any, path: str) -> List[Any]:
+    if not isinstance(value, list):
+        raise ValueError("promptfoo %s must be a JSON array" % path)
+    return value
+
+
+def _nonempty_string(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("promptfoo %s must be a non-empty string" % path)
+    return value.strip()
+
+
+def _finite_number(value: Any, path: str, *, nonnegative: bool = False) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("promptfoo %s must be a finite number" % path)
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError("promptfoo %s must be a finite number" % path)
+    if nonnegative and number < 0:
+        raise ValueError("promptfoo %s must be a non-negative finite number" % path)
+    return number
+
+
+def _count(value: Any, path: str) -> int:
+    number = _finite_number(value, path, nonnegative=True)
+    if not number.is_integer():
+        raise ValueError("promptfoo %s must be an integer count" % path)
+    return int(number)
+
+
+def _optional_metric(
+    target: Dict[str, float], source: Dict[str, Any], source_name: str, target_name: str
+) -> None:
+    if source_name not in source or source[source_name] is None:
+        return
+    target[target_name] = _finite_number(
+        source[source_name], "results.stats.tokenUsage.%s" % source_name, nonnegative=True
+    )
+
+
+def promptfoo_artifact_from_export(
+    payload: Dict[str, Any], *, source_revision: Optional[str] = None
+) -> EvaluationArtifact:
+    """Convert a promptfoo OutputFile with EvaluateSummaryV3 into aggregate evidence.
+
+    Raw prompts, responses, test variables, configuration, traces, named scores, and
+    arbitrary metadata are intentionally excluded from the returned artifact.
+    """
+
+    root = _object(payload, "export")
+    metadata = _object(root.get("metadata"), "metadata")
+    producer_version = _nonempty_string(
+        metadata.get("promptfooVersion"), "metadata.promptfooVersion"
+    )
+    if not _SEMVER.fullmatch(producer_version):
+        raise ValueError("promptfoo metadata.promptfooVersion must be a semantic version")
+
+    summary = _object(root.get("results"), "results")
+    version = summary.get("version")
+    if isinstance(version, bool) or version != PROMPTFOO_SCHEMA_VERSION:
+        raise ValueError(
+            "promptfoo export must use supported results schema version %s"
+            % PROMPTFOO_SCHEMA_VERSION
+        )
+    source_timestamp = _nonempty_string(summary.get("timestamp"), "results.timestamp")
+    rows = _array(summary.get("results"), "results.results")
+    if not rows:
+        raise ValueError("promptfoo results.results must contain at least one result row")
+
+    successes = 0
+    failures = 0
+    errors = 0
+    scores: List[float] = []
+    latencies: List[float] = []
+    costs: List[float] = []
+    all_rows_have_cost = True
+
+    for index, raw_row in enumerate(rows):
+        row = _object(raw_row, "results.results[%s]" % index)
+        success = row.get("success")
+        if not isinstance(success, bool):
+            raise ValueError(
+                "promptfoo results.results[%s].success must be a boolean" % index
+            )
+        failure_reason = _count(
+            row.get("failureReason"), "results.results[%s].failureReason" % index
+        )
+        if failure_reason not in {0, 1, 2}:
+            raise ValueError(
+                "promptfoo results.results[%s].failureReason is not supported" % index
+            )
+        if success:
+            if failure_reason != 0:
+                raise ValueError(
+                    "promptfoo results.results[%s] has inconsistent success evidence" % index
+                )
+            successes += 1
+        elif failure_reason == 2:
+            errors += 1
+        else:
+            failures += 1
+
+        scores.append(_finite_number(row.get("score"), "results.results[%s].score" % index))
+        latencies.append(
+            _finite_number(
+                row.get("latencyMs"),
+                "results.results[%s].latencyMs" % index,
+                nonnegative=True,
+            )
+        )
+        if "cost" not in row or row["cost"] is None:
+            all_rows_have_cost = False
+        else:
+            costs.append(
+                _finite_number(
+                    row["cost"], "results.results[%s].cost" % index, nonnegative=True
+                )
+            )
+
+    stats = _object(summary.get("stats"), "results.stats")
+    declared_counts = (
+        _count(stats.get("successes"), "results.stats.successes"),
+        _count(stats.get("failures"), "results.stats.failures"),
+        _count(stats.get("errors"), "results.stats.errors"),
+    )
+    if declared_counts != (successes, failures, errors):
+        raise ValueError("promptfoo results.stats counts do not match result rows")
+
+    metrics: Dict[str, float] = {
+        "promptfoo_pass_rate": successes / len(rows),
+        "promptfoo_mean_score": sum(scores) / len(scores),
+        "latency_ms": sum(latencies) / len(latencies),
+        "test_cases": float(len(rows)),
+    }
+    if all_rows_have_cost:
+        metrics["total_cost_usd"] = sum(costs)
+
+    token_usage = _object(stats.get("tokenUsage"), "results.stats.tokenUsage")
+    _optional_metric(metrics, token_usage, "prompt", "input_tokens")
+    _optional_metric(metrics, token_usage, "completion", "output_tokens")
+
+    run_id_value = root.get("evalId")
+    if run_id_value is not None:
+        run_id = _nonempty_string(run_id_value, "evalId")
+    else:
+        run_id = None
+
+    sanitized_metadata: Dict[str, Any] = {
+        "adapter": "evalforge.promptfoo",
+        "adapter_mapping_version": ADAPTER_MAPPING_VERSION,
+        "source_schema_version": PROMPTFOO_SCHEMA_VERSION,
+        "source_timestamp": source_timestamp,
+    }
+    if metadata.get("exportedAt") is not None:
+        sanitized_metadata["source_exported_at"] = _nonempty_string(
+            metadata["exportedAt"], "metadata.exportedAt"
+        )
+
+    return artifact_from_summary(
+        metrics,
+        producer_name="promptfoo",
+        producer_version=producer_version,
+        run_id=run_id,
+        source_revision=source_revision,
+        metadata=sanitized_metadata,
+    )
+
+
+def load_promptfoo_export(
+    path: Path, *, source_revision: Optional[str] = None
+) -> EvaluationArtifact:
+    """Read and convert a promptfoo JSON export from disk."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError("Could not read promptfoo export %s: %s" % (path, exc)) from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError("promptfoo export %s is not valid JSON: %s" % (path, exc)) from exc
+    return promptfoo_artifact_from_export(payload, source_revision=source_revision)

--- a/src/evalforge/artifacts.py
+++ b/src/evalforge/artifacts.py
@@ -24,6 +24,8 @@ METRIC_METADATA: Dict[str, Tuple[str, str]] = {
     "test_cases": ("count", "neutral"),
     "security_cases": ("count", "neutral"),
     "security_pass_rate": ("ratio", "higher"),
+    "promptfoo_pass_rate": ("ratio", "higher"),
+    "promptfoo_mean_score": ("score", "higher"),
 }
 
 

--- a/src/evalforge/cli.py
+++ b/src/evalforge/cli.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import typer
 
+from evalforge.adapters.promptfoo import load_promptfoo_export
 from evalforge.artifacts import artifact_from_summary, load_artifact, write_artifact
 from evalforge.gates import (
     GateCheck,
@@ -22,6 +23,28 @@ from evalforge.gates import (
 )
 
 app = typer.Typer(help="EvalForge command-line tools")
+import_app = typer.Typer(help="Convert an explicit evaluator format to EvalForge evidence")
+app.add_typer(import_app, name="import")
+
+
+@import_app.command("promptfoo")
+def import_promptfoo(
+    source: Path,
+    output: Path = typer.Option(..., "--output", "-o"),
+    source_revision: Optional[str] = typer.Option(
+        None,
+        "--source-revision",
+        help="Candidate source revision evaluated by promptfoo",
+    ),
+) -> None:
+    """Convert a promptfoo JSON OutputFile (results schema v3)."""
+
+    try:
+        artifact = load_promptfoo_export(source, source_revision=source_revision)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    write_artifact(output, artifact)
+    typer.echo("Wrote promptfoo evaluation artifact to %s" % output)
 
 
 def _require_rag_dependencies() -> None:

--- a/tests/fixtures/promptfoo/README.md
+++ b/tests/fixtures/promptfoo/README.md
@@ -1,0 +1,13 @@
+# promptfoo fixture provenance
+
+`results-v3.json` is a synthetic fixture written for EvalForge. It follows the
+promptfoo JSON `OutputFile` / `EvaluateSummaryV3` structure verified at:
+
+- promptfoo version: `0.122.2`
+- upstream commit: `9cd19241a0706fcf59dd609167f4218612fc4beb`
+- output documentation: <https://www.promptfoo.dev/docs/configuration/outputs/>
+- type definitions: <https://github.com/promptfoo/promptfoo/blob/9cd19241a0706fcf59dd609167f4218612fc4beb/src/types/index.ts>
+
+The values, prompts, identifiers, and fake secret are invented and are not
+copied from an upstream evaluation. promptfoo is MIT licensed; its license is
+available at <https://github.com/promptfoo/promptfoo/blob/9cd19241a0706fcf59dd609167f4218612fc4beb/LICENSE>.

--- a/tests/fixtures/promptfoo/results-v3.json
+++ b/tests/fixtures/promptfoo/results-v3.json
@@ -1,0 +1,75 @@
+{
+  "evalId": "eval-synthetic-001",
+  "results": {
+    "version": 3,
+    "timestamp": "2026-08-31T08:00:00.000Z",
+    "results": [
+      {
+        "promptIdx": 0,
+        "testIdx": 0,
+        "testCase": {},
+        "promptId": "prompt-1",
+        "provider": {"id": "example:provider", "label": "Synthetic provider"},
+        "prompt": {"raw": "Synthetic prompt", "label": "Synthetic prompt"},
+        "vars": {},
+        "failureReason": 0,
+        "success": true,
+        "score": 0.9,
+        "latencyMs": 100,
+        "namedScores": {"unsupported_custom_score": 0.4},
+        "cost": 0.001,
+        "tokenUsage": {"prompt": 10, "completion": 5, "cached": 0, "total": 15, "numRequests": 1}
+      },
+      {
+        "promptIdx": 0,
+        "testIdx": 1,
+        "testCase": {},
+        "promptId": "prompt-1",
+        "provider": {"id": "example:provider", "label": "Synthetic provider"},
+        "prompt": {"raw": "Synthetic prompt", "label": "Synthetic prompt"},
+        "vars": {},
+        "failureReason": 0,
+        "success": true,
+        "score": 0.8,
+        "latencyMs": 200,
+        "namedScores": {},
+        "cost": 0.002,
+        "tokenUsage": {"prompt": 10, "completion": 5, "cached": 0, "total": 15, "numRequests": 1}
+      },
+      {
+        "promptIdx": 0,
+        "testIdx": 2,
+        "testCase": {},
+        "promptId": "prompt-1",
+        "provider": {"id": "example:provider", "label": "Synthetic provider"},
+        "prompt": {"raw": "Synthetic prompt", "label": "Synthetic prompt"},
+        "vars": {},
+        "failureReason": 1,
+        "success": false,
+        "score": 0.2,
+        "latencyMs": 300,
+        "namedScores": {},
+        "cost": 0.003,
+        "tokenUsage": {"prompt": 10, "completion": 5, "cached": 0, "total": 15, "numRequests": 1}
+      }
+    ],
+    "prompts": [],
+    "stats": {
+      "successes": 2,
+      "failures": 1,
+      "errors": 0,
+      "tokenUsage": {"prompt": 30, "completion": 15, "cached": 0, "total": 45, "numRequests": 3}
+    }
+  },
+  "config": {"env": {"SYNTHETIC_API_KEY": "must-not-leak"}},
+  "shareableUrl": null,
+  "metadata": {
+    "promptfooVersion": "0.122.2",
+    "nodeVersion": "v24.7.0",
+    "platform": "synthetic",
+    "arch": "synthetic",
+    "exportedAt": "2026-08-31T08:01:00.000Z",
+    "futureMetadataField": "ignored"
+  },
+  "futureTopLevelField": "ignored"
+}

--- a/tests/test_artifacts_gates.py
+++ b/tests/test_artifacts_gates.py
@@ -32,8 +32,9 @@ def test_committed_examples_match_normative_json_schemas():
     for name in ["baseline_summary.json", "candidate_summary.json"]:
         payload = json.loads((ROOT / "examples" / name).read_text(encoding="utf-8"))
         jsonschema.validate(payload, artifact_schema)
-    policy = json.loads((ROOT / "examples" / "quality_policy.json").read_text(encoding="utf-8"))
-    jsonschema.validate(policy, policy_schema)
+    for name in ["quality_policy.json", "promptfoo_policy.json"]:
+        policy = json.loads((ROOT / "examples" / name).read_text(encoding="utf-8"))
+        jsonschema.validate(policy, policy_schema)
 
 
 def test_flat_summary_becomes_portable_artifact(tmp_path):

--- a/tests/test_promptfoo_adapter.py
+++ b/tests/test_promptfoo_adapter.py
@@ -1,0 +1,127 @@
+import json
+import math
+from pathlib import Path
+
+import jsonschema
+import pytest
+from typer.testing import CliRunner
+
+from evalforge.adapters.promptfoo import promptfoo_artifact_from_export
+from evalforge.cli import app
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests" / "fixtures" / "promptfoo" / "results-v3.json"
+
+
+def _payload():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_promptfoo_v3_export_becomes_schema_valid_sanitized_artifact():
+    artifact = promptfoo_artifact_from_export(_payload(), source_revision="abc123")
+
+    assert artifact.producer.name == "promptfoo"
+    assert artifact.producer.version == "0.122.2"
+    assert artifact.run.id == "eval-synthetic-001"
+    assert artifact.run.source_revision == "abc123"
+    assert artifact.metrics["promptfoo_pass_rate"].value == pytest.approx(2 / 3)
+    assert artifact.metrics["promptfoo_mean_score"].value == pytest.approx(1.9 / 3)
+    assert artifact.metrics["latency_ms"].value == pytest.approx(200)
+    assert artifact.metrics["total_cost_usd"].value == pytest.approx(0.006)
+    assert artifact.metrics["input_tokens"].value == 30
+    assert artifact.metrics["output_tokens"].value == 15
+    assert artifact.metrics["test_cases"].value == 3
+    assert "unsupported_custom_score" not in artifact.metrics
+
+    serialized = artifact.model_dump(mode="json", exclude_none=True, by_alias=True)
+    jsonschema.validate(
+        serialized,
+        json.loads(
+            (ROOT / "schemas" / "evaluation-artifact-v1.schema.json").read_text(
+                encoding="utf-8"
+            )
+        ),
+    )
+    assert "must-not-leak" not in json.dumps(serialized)
+    assert artifact.metadata == {
+        "adapter": "evalforge.promptfoo",
+        "adapter_mapping_version": "1",
+        "source_exported_at": "2026-08-31T08:01:00.000Z",
+        "source_schema_version": 3,
+        "source_timestamp": "2026-08-31T08:00:00.000Z",
+    }
+
+
+def test_promptfoo_import_ignores_forward_compatible_and_unknown_metric_fields():
+    payload = _payload()
+    payload["results"]["futureSummaryField"] = {"value": 99}
+    payload["results"]["results"][0]["futureResultField"] = math.pi
+    payload["results"]["results"][0]["namedScores"]["future_metric"] = 0.99
+
+    artifact = promptfoo_artifact_from_export(payload)
+
+    assert set(artifact.metrics) == {
+        "input_tokens",
+        "latency_ms",
+        "output_tokens",
+        "promptfoo_mean_score",
+        "promptfoo_pass_rate",
+        "test_cases",
+        "total_cost_usd",
+    }
+
+
+def test_promptfoo_import_requires_versioned_provenance():
+    payload = _payload()
+    del payload["metadata"]["promptfooVersion"]
+
+    with pytest.raises(ValueError, match="metadata.promptfooVersion"):
+        promptfoo_artifact_from_export(payload)
+
+
+def test_promptfoo_import_rejects_unknown_schema_version():
+    payload = _payload()
+    payload["results"]["version"] = 4
+
+    with pytest.raises(ValueError, match="schema version 3"):
+        promptfoo_artifact_from_export(payload)
+
+
+@pytest.mark.parametrize("field", ["score", "latencyMs", "cost"])
+def test_promptfoo_import_rejects_non_finite_result_values(field):
+    payload = _payload()
+    payload["results"]["results"][0][field] = math.nan
+
+    with pytest.raises(ValueError, match="finite number"):
+        promptfoo_artifact_from_export(payload)
+
+
+def test_promptfoo_import_rejects_inconsistent_stats():
+    payload = _payload()
+    payload["results"]["stats"]["successes"] = 1
+
+    with pytest.raises(ValueError, match="do not match result rows"):
+        promptfoo_artifact_from_export(payload)
+
+
+def test_promptfoo_cli_imports_explicit_format(tmp_path):
+    output = tmp_path / "artifact.json"
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "import",
+            "promptfoo",
+            str(FIXTURE),
+            "--output",
+            str(output),
+            "--source-revision",
+            "abc123",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["producer"] == {"name": "promptfoo", "version": "0.122.2"}
+    assert payload["run"] == {"id": "eval-synthetic-001", "source_revision": "abc123"}
+    assert "Wrote promptfoo evaluation artifact" in result.output

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,42 @@
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_third_party_actions_are_pinned_to_full_commit_shas():
+    workflow_files = list((ROOT / ".github" / "workflows").glob("*.yml"))
+    workflow_files.append(ROOT / "action.yml")
+    uses_pattern = re.compile(r"^\s*-?\s*uses:\s*([^\s#]+)", re.MULTILINE)
+
+    for path in workflow_files:
+        for reference in uses_pattern.findall(path.read_text(encoding="utf-8")):
+            assert re.search(r"@[0-9a-f]{40}$", reference), (
+                "%s contains an unpinned Action reference: %s" % (path, reference)
+            )
+
+
+def test_pypi_oidc_permission_is_scoped_to_publish_job():
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert workflow.count("id-token: write") == 1
+    publish_job = workflow.split("  pypi-publish:", 1)[1]
+    assert "id-token: write" in publish_job
+    assert "environment:\n      name: pypi" in publish_job
+    assert "password:" not in workflow
+    assert "PYPI_API_TOKEN" not in workflow
+
+
+def test_codeql_uses_minimal_write_permission_and_pinned_release():
+    workflow = (ROOT / ".github" / "workflows" / "codeql.yml").read_text(encoding="utf-8")
+
+    assert workflow.count("security-events: write") == 1
+    assert "contents: write" not in workflow
+    assert workflow.count("cdf488f595d80d6e07e03d4674febd5ab45fa938") == 2
+
+
+def test_dependabot_respects_python_39_tooling_caps():
+    config = (ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8")
+
+    assert "dependency-name: mypy\n        update-types: [version-update:semver-major]" in config
+    assert "dependency-name: twine\n        update-types: [version-update:semver-major]" in config


### PR DESCRIPTION
## Problem

AI evaluation tools produce different result shapes, while release systems need small, reviewable evidence and stable pass/fail policy gates. EvalForge also needed a safer release path before a public package can be published.

## Change

- add an explicit promptfoo `OutputFile` / `EvaluateSummaryV3` schema-v3 adapter
- add `evalforge import promptfoo` and a documented policy example
- preserve data minimization: aggregate metrics and provenance are imported, not raw prompts, responses, traces, or config
- add CodeQL and pin third-party GitHub Actions by commit SHA
- build release artifacts once, verify them, and reuse the same artifacts for GitHub and PyPI
- switch PyPI publishing to OIDC with a protected `pypi` environment
- bump the project to v0.3.1 and update interoperability, ecosystem, citation, and release documentation

## Evidence

- [x] Tests added or updated
- [x] `make lint` passes
- [x] `make test` passes: 54 tests, 86.66% coverage (minimum 85%)
- [x] `make release-check` passes for wheel and sdist
- [x] actionlint passes
- [x] fresh-wheel CLI import and gate smoke tests pass
- [x] extracted-sdist test suite passes
- [x] Documentation updated
- [x] Artifact, policy, and metric compatibility impact described

## Compatibility

The EvalForge artifact schema remains at 1.0. Existing gate behavior stays compatible. The new adapter only adds a documented import path and promptfoo-derived metric names.

## Security and data

The adapter intentionally rejects unsupported export shapes and only emits aggregate evaluation evidence plus narrow provenance. The release job receives `id-token: write` only in the PyPI publish job, and publishing is blocked until the repository environment and PyPI Trusted Publisher are configured.

## Release note

Please squash-merge this PR. Do not create the v0.3.1 tag until the protected `pypi` environment and PyPI Trusted Publisher are configured and verified.
