### PR TITLE
feat: ship v0.4.0 evaluator interoperability and auditable gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,41 @@ jobs:
           python -m json.tool artifacts/promptfoo.sarif >/dev/null
           python -c "from xml.etree import ElementTree; ElementTree.parse('artifacts/evalforge-junit.xml')"
           python -c "from xml.etree import ElementTree; ElementTree.parse('artifacts/promptfoo-junit.xml')"
+      - name: Exercise Ragas and DeepEval imports without evaluator dependencies
+        if: matrix.python-version == '3.12'
+        run: |
+          evalforge import ragas tests/fixtures/ragas/evaluation-result-records.json \
+            --producer-version 0.2.12 --metric faithfulness --metric answer_relevancy \
+            --source-revision "$GITHUB_SHA" --output artifacts/ragas-artifact.json
+          evalforge gate artifacts/ragas-artifact.json --policy examples/ragas_policy.json \
+            --json artifacts/ragas-report.json --markdown artifacts/ragas-summary.md
+          evalforge import deepeval tests/fixtures/deepeval/evaluation-result-4.2.2.json \
+            --producer-version 4.2.2 --source-revision "$GITHUB_SHA" \
+            --output artifacts/deepeval-artifact.json
+          evalforge gate artifacts/deepeval-artifact.json --policy examples/deepeval_policy.json \
+            --json artifacts/deepeval-report.json --markdown artifacts/deepeval-summary.md
+      - name: Demonstrate dataset-mismatch blocking
+        if: matrix.python-version == '3.12'
+        run: |
+          evalforge gate examples/strict-comparison/candidate.json \
+            --baseline examples/strict-comparison/baseline.json \
+            --policy examples/strict-comparison/policy.json
+          gate_status=0
+          evalforge gate examples/strict-comparison/changed-dataset.json \
+            --baseline examples/strict-comparison/baseline.json \
+            --policy examples/strict-comparison/policy.json \
+            --json artifacts/blocked-report.json \
+            --markdown artifacts/blocked-summary.md || gate_status=$?
+          test "$gate_status" -eq 1
+          python -c "import json; p=json.load(open('artifacts/blocked-report.json')); assert not p['passed']; assert all(c['outcome']=='error' for c in p['checks'])"
+      - name: Preserve evaluation evidence
+        if: always() && matrix.python-version == '3.12'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: evaluation-evidence
+          path: artifacts/
+          if-no-files-found: warn
+          retention-days: 14
       - name: Build and check distributions
         if: matrix.python-version == '3.12'
         run: make release-check
@@ -71,6 +106,11 @@ jobs:
             --json "$RUNNER_TEMP/evalforge-wheel/report.json" \
             --junit "$RUNNER_TEMP/evalforge-wheel/junit.xml" \
             --sarif "$RUNNER_TEMP/evalforge-wheel/report.sarif"
+          "$RUNNER_TEMP/evalforge-wheel/bin/python" -c "import importlib.util; assert all(importlib.util.find_spec(p) is None for p in ('ragas', 'deepeval', 'sqlalchemy', 'streamlit'))"
+          "$RUNNER_TEMP/evalforge-wheel/bin/evalforge" import ragas tests/fixtures/ragas/evaluation-result-records.json \
+            --producer-version 0.2.12 --metric faithfulness --output "$RUNNER_TEMP/evalforge-wheel/ragas.json"
+          "$RUNNER_TEMP/evalforge-wheel/bin/evalforge" import deepeval tests/fixtures/deepeval/evaluation-result-4.2.2.json \
+            --producer-version 4.2.2 --output "$RUNNER_TEMP/evalforge-wheel/deepeval.json"
 
   docker:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes are documented here. The project follows semantic versioning while the artifact and policy formats carry independent schema versions.
 
+## [0.4.0] - 2026-09-10
+
+### Added
+
+- Offline Ragas records import with explicit metric columns, complete-row validation, and aggregate-only artifacts.
+- DeepEval 3.8.1 and 4.2.2 result imports with a reviewed built-in metric allowlist and separate names for score semantics that changed between major versions.
+- Opt-in policy requirements for matching dataset fingerprints, exact producer versions, and metric-definition identities; missing or mismatched evidence fails closed.
+- SHA-256 digests of normalized candidate, baseline, and policy inputs, with source revisions and producer identity in CI reports.
+- Markdown reports and GitHub Action job summaries, including blocked gates, plus Action exit-code/report outputs.
+- Reproducible strict-comparison examples, adapter conformance fixtures, a full CI adoption recipe, and a dated OSS evidence map.
+
+### Fixed
+
+- Preserve dataset and metric-version identities when loading API summary envelopes.
+- Reject boolean and numeric-string coercion in canonical metric values and policy thresholds.
+- Fail safely when subtraction of finite metric values overflows, instead of producing a passing infinite delta.
+- Keep malformed identity objects and arbitrary artifact metadata out of report evidence.
+
+### Compatibility
+
+- Python 3.9 remains supported; base installation still needs only Pydantic and Typer.
+- Artifact schema 1.0 and policy version 1 gain optional fields. Existing policies remain unchanged unless strict comparison is explicitly enabled.
+- Producer declarations and input digests support traceability; they are not signatures, independent adoption evidence, or proof of scientific validity.
+
 ## [0.3.1] - 2026-08-31
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If EvalForge supports your research or engineering work, please cite the software.
 title: EvalForge
 type: software
-version: 0.3.1
-date-released: 2026-08-31
+version: 0.4.0
+date-released: 2026-09-10
 license: MIT
 repository-code: https://github.com/jsdhwfmax/EvalForge
 url: https://github.com/jsdhwfmax/EvalForge

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 [![Python](https://img.shields.io/badge/Python-3.9%2B-3776AB.svg)](https://www.python.org/)
 [![GitHub stars](https://img.shields.io/github/stars/jsdhwfmax/EvalForge?style=flat)](https://github.com/jsdhwfmax/EvalForge/stargazers)
 
-EvalForge turns AI evaluation results into reviewable release evidence. It includes a transparent RAG evaluator, a vendor-neutral JSON artifact, and policy-as-code gates that emit JSON, JUnit, and SARIF for existing CI systems.
+EvalForge turns AI evaluation results into reviewable release evidence. Import promptfoo, Ragas, or supported DeepEval results, enforce a versioned policy, and publish JSON, JUnit, SARIF, and Markdown reports in your existing CI system. The gate runs offline with two direct dependencies and no hosted account.
 
-> Status: v0.3.1 alpha. The gate and offline evaluator are usable today; artifact schema 1.0 is intentionally small while interoperability feedback is collected.
+> Status: v0.4.0 alpha. The gate and offline evaluator are usable today. Integrations have explicit, tested format boundaries; the project is still seeking independently verified downstream adoption.
 
 ## Why EvalForge?
 
@@ -27,14 +27,16 @@ EvalForge provides that missing, deliberately narrow interoperability layer. It 
 4. Apply explicit quality, security, latency, and cost thresholds.
 5. Emit a portable artifact plus JSON, JUnit, and SARIF reports; return a non-zero exit code on regression.
 
-Read the engineering narrative in the [case study](docs/CASE_STUDY.md) or use the [resume-ready project notes](docs/PORTFOLIO.md).
+Read the [CI cookbook](docs/CI_COOKBOOK.md) for a reproducible dataset-mismatch failure and a complete GitHub workflow, or the [case study](docs/CASE_STUDY.md) for the RAG evaluator's engineering trade-offs.
 
 | Capability | Included |
 |---|---|
 | Portable evidence | Versioned, evaluator-neutral JSON artifact and JSON Schemas |
-| Evaluator adapters | Explicit promptfoo JSON v3 import with sanitized aggregate evidence |
+| Evaluator adapters | promptfoo schema v3, Ragas selected score records, DeepEval 3.8.1 / 4.2.2 |
+| Comparable baselines | Opt-in matching of dataset, evaluator version, and metric-definition identity |
+| Audit evidence | Deterministic SHA-256 input/policy digests plus producer and source revision |
 | Policy gates | Absolute thresholds, baseline deltas, errors and advisory warnings |
-| CI reports | Stable exit codes plus JSON, JUnit XML, and SARIF 2.1.0 |
+| CI reports | Stable exit codes plus JSON, JUnit XML, SARIF 2.1.0, and Markdown job summaries |
 | GitHub integration | Reusable composite Action with no hosted EvalForge account |
 | Golden datasets | JSON import API, file upload, CLI, example dataset |
 | Retrieval | BM25, deterministic vector, hybrid; configurable Recall@K |
@@ -53,6 +55,14 @@ Read the engineering narrative in the [case study](docs/CASE_STUDY.md) or use th
 
 ### Quality gate (no server or model key)
 
+Install from PyPI:
+
+```bash
+pip install evalforge-ci
+```
+
+For the committed examples and source development:
+
 ```bash
 git clone https://github.com/jsdhwfmax/EvalForge.git
 cd EvalForge
@@ -65,7 +75,8 @@ evalforge gate examples/candidate_summary.json \
   --baseline examples/baseline_summary.json \
   --json build/evalforge-report.json \
   --junit build/evalforge-junit.xml \
-  --sarif build/evalforge.sarif
+  --sarif build/evalforge.sarif \
+  --markdown build/evalforge-summary.md
 ```
 
 The committed example passes required checks and reports one advisory answer-quality regression. Gate exit codes are `0` for pass, `1` for a failed/error check, and `2` for invalid input or policy configuration.
@@ -97,6 +108,48 @@ The adapter requires promptfoo results schema 3 and versioned producer
 metadata. It is verified against promptfoo 0.122.2; see the exact metric
 mapping and privacy boundary in the
 [interoperability specification](docs/INTEROPERABILITY.md#promptfoo-adapter).
+
+### Import Ragas or DeepEval evidence
+
+Export Ragas results with `result.to_pandas().to_json(..., orient="records")`.
+Choose score columns explicitly so sample content never becomes a metric:
+
+```bash
+evalforge import ragas tests/fixtures/ragas/evaluation-result-records.json \
+  --producer-version 0.2.12 --metric faithfulness --metric answer_relevancy \
+  --dataset-fingerprint synthetic-ragas-fixture-v1 \
+  --metric-version ragas-demo-rubric-v1 --output build/ragas.json
+evalforge gate build/ragas.json --policy examples/ragas_policy.json
+```
+
+DeepEval imports the JSON serialization of `EvaluationResult` using a verified
+producer version. Raw inputs, outputs, reasons, traces, and custom metric names
+are excluded from the portable artifact:
+
+```bash
+evalforge import deepeval tests/fixtures/deepeval/evaluation-result-4.2.2.json \
+  --producer-version 4.2.2 --output build/deepeval.json
+evalforge gate build/deepeval.json --policy examples/deepeval_policy.json
+```
+
+These fixtures contain synthetic scores and demonstrate interoperability, not
+model quality. Missing or errored selected evidence fails the import. DeepEval
+metrics whose meaning changed between v3 and v4 receive separate names, so
+opposite score directions cannot silently share a baseline. See the precise
+[Ragas](docs/integrations/ragas.md) and [DeepEval](docs/integrations/deepeval.md)
+contracts and their upstream fixture provenance.
+
+### Require comparable evidence
+
+A higher score on a different test set does not establish an improvement. Add
+the optional `comparison` policy object to require matching dataset fingerprints,
+producer name/version, or metric-definition versions. Imports accept
+`--dataset-fingerprint` and `--metric-version` for these explicit identities.
+Missing or mismatched required identity blocks the gate, even for warning checks.
+
+The [CI cookbook](docs/CI_COOKBOOK.md#reproduce-a-misleading-green-check) includes
+passing and blocked examples, migration guidance, and the digest specification.
+Existing policies retain their behavior unless these comparison options are enabled.
 
 ### Docker (recommended)
 
@@ -150,14 +203,14 @@ The command prints the measured summary, writes a portable evaluation artifact p
 ### GitHub Action
 
 ```yaml
-- uses: jsdhwfmax/EvalForge@v0.3.1
+- uses: jsdhwfmax/EvalForge@v0.4.0
   with:
     candidate: build/candidate.json
     baseline: build/baseline.json
     policy: evalforge-policy.json
 ```
 
-The Action writes `evalforge-report.json`, `evalforge-junit.xml`, and `evalforge.sarif` by default. Upload them with the standard reporting actions already used by your repository. Pin a full commit SHA where your supply-chain policy requires immutable Actions.
+The Action writes `evalforge-report.json`, `evalforge-junit.xml`, `evalforge.sarif`, and `evalforge-summary.md`. It appends the summary to the GitHub job page even when the gate blocks a release. Use `if: always()` when uploading reports; the [complete workflow](docs/CI_COOKBOOK.md#keep-reports-when-the-gate-fails) shows how. Pin a full commit SHA where your supply-chain policy requires immutable Actions.
 
 Using EvalForge in another public repository? Please open an issue or pull request to add it to [ADOPTERS.md](ADOPTERS.md). Projects are listed only with a maintainer's consent and a public, verifiable integration link.
 
@@ -334,7 +387,7 @@ make lint
 make test
 ```
 
-The 54-test suite covers portable artifacts, policy behavior, all three CI report formats, CLI exit codes, retrieval ranking, metrics, security grading, persistence, API validation, dataset fingerprints, baseline comparisons, promptfoo interoperability, release-workflow invariants, and complete multi-configuration experiments. Current measured branch-aware coverage is 86.66%.
+The test suite covers portable artifacts, strict comparison identities, digest stability, four CI report formats, CLI exit codes, three evaluator adapters, retrieval, metrics, security grading, persistence, and complete multi-configuration experiments. CI enforces at least 85% branch-aware coverage; see the linked CI run for the current measured result.
 
 CI runs on Python 3.9 and 3.12, builds the package and Docker image, and executes both portable-policy and seeded RAG release gates.
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,25 @@ inputs:
     description: SARIF 2.1.0 report path.
     required: false
     default: evalforge.sarif
+  markdown-output:
+    description: Markdown gate summary path.
+    required: false
+    default: evalforge-summary.md
+  job-summary:
+    description: Append the Markdown report to the GitHub job summary, including on failure.
+    required: false
+    default: "true"
+
+outputs:
+  exit-code:
+    description: Gate exit code (0 pass, 1 blocked, 2 invalid input).
+    value: ${{ steps.gate.outputs.exit-code }}
+  json-report:
+    description: Path to the JSON report.
+    value: ${{ inputs.json-output }}
+  markdown-report:
+    description: Path to the Markdown summary.
+    value: ${{ inputs.markdown-output }}
 
 runs:
   using: composite
@@ -45,6 +64,7 @@ runs:
       shell: bash
       run: python -m pip install "$GITHUB_ACTION_PATH"
     - name: Enforce evaluation policy
+      id: gate
       shell: bash
       env:
         EVALFORGE_CANDIDATE: ${{ inputs.candidate }}
@@ -53,12 +73,27 @@ runs:
         EVALFORGE_JSON: ${{ inputs.json-output }}
         EVALFORGE_JUNIT: ${{ inputs.junit-output }}
         EVALFORGE_SARIF: ${{ inputs.sarif-output }}
+        EVALFORGE_MARKDOWN: ${{ inputs.markdown-output }}
+        EVALFORGE_JOB_SUMMARY: ${{ inputs.job-summary }}
       run: |
         args=("$EVALFORGE_CANDIDATE" --policy "$EVALFORGE_POLICY")
         if [[ -n "$EVALFORGE_BASELINE" ]]; then
           args+=(--baseline "$EVALFORGE_BASELINE")
         fi
+        summary_dir=$(mktemp -d)
+        trap 'rm -rf "$summary_dir"' EXIT
+        gate_status=0
         evalforge gate "${args[@]}" \
           --json "$EVALFORGE_JSON" \
           --junit "$EVALFORGE_JUNIT" \
-          --sarif "$EVALFORGE_SARIF"
+          --sarif "$EVALFORGE_SARIF" \
+          --markdown "$summary_dir/summary.md" || gate_status=$?
+        echo "exit-code=$gate_status" >> "$GITHUB_OUTPUT"
+        if [[ -f "$summary_dir/summary.md" ]]; then
+          mkdir -p "$(dirname "$EVALFORGE_MARKDOWN")"
+          cp "$summary_dir/summary.md" "$EVALFORGE_MARKDOWN"
+          if [[ "$EVALFORGE_JOB_SUMMARY" == "true" ]]; then
+            cat "$summary_dir/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+        fi
+        exit "$gate_status"

--- a/docs/CI_COOKBOOK.md
+++ b/docs/CI_COOKBOOK.md
@@ -1,0 +1,116 @@
+# Put evaluation evidence into CI
+
+Install the gate with `pip install evalforge-ci`. It needs neither a model key
+nor the Ragas, DeepEval, dashboard, or database dependencies. Run your evaluator
+in its own environment, export its results, then import the documented format.
+
+## Reproduce a misleading green check
+
+The files in `examples/strict-comparison/` contain synthetic scores, not a model
+benchmark. Both candidates improve the numerical score. The second candidate
+changes the dataset, so its improvement cannot establish a regression result.
+
+```bash
+evalforge gate examples/strict-comparison/candidate.json \
+  --baseline examples/strict-comparison/baseline.json \
+  --policy examples/strict-comparison/policy.json \
+  --markdown build/summary.md --json build/report.json
+# Exit 0: comparable evidence and passing scores.
+
+evalforge gate examples/strict-comparison/changed-dataset.json \
+  --baseline examples/strict-comparison/baseline.json \
+  --policy examples/strict-comparison/policy.json \
+  --markdown build/blocked.md --json build/blocked.json
+# Exit 1: both checks report a dataset_fingerprint mismatch, despite quality=0.99.
+```
+
+Strict comparison is opt-in. Existing flat JSON summaries keep working with
+existing policies. Add a `comparison` object to a reviewed policy:
+
+```json
+{
+  "require_same_dataset": true,
+  "require_same_producer": true,
+  "require_same_metric_version": true
+}
+```
+
+Each enabled requirement needs a baseline, even for an absolute-only policy.
+`dataset_fingerprint` and `metric_version` must be non-empty strings in both
+artifacts' `metadata`. The producer requirement compares both name and exact
+version and rejects `unknown` versions. Missing or mismatched identity fails
+every check as an error, including checks marked as advisory warnings.
+
+Choose fingerprints from the actual, canonicalized dataset and metric setup.
+These are producer declarations: EvalForge cannot verify that an evaluator
+truthfully labeled the data or that two judge executions are scientifically
+equivalent. Reset a baseline deliberately when its measurement definition changes.
+
+## Keep reports when the gate fails
+
+This complete workflow assumes your repository commits a trusted baseline and
+policy, and its evaluation step produces `build/candidate.json`. Replace that
+step with the evaluator command used by your project. Avoid loading secrets or
+running untrusted pull-request code in a privileged `pull_request_target` job.
+
+```yaml
+name: Evaluation gate
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Run your evaluator
+        run: python scripts/evaluate.py --output build/candidate.json
+      - uses: jsdhwfmax/EvalForge@v0.4.0
+        id: evalforge
+        with:
+          candidate: build/candidate.json
+          baseline: evaluation/baseline.json
+          policy: evaluation/policy.json
+      - name: Preserve gate evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: evalforge-evidence
+          path: |
+            evalforge-report.json
+            evalforge-junit.xml
+            evalforge.sarif
+            evalforge-summary.md
+          if-no-files-found: warn
+```
+
+The Action preserves the CLI failure exit code and appends the Markdown report
+to the GitHub job summary for both passing and blocked gates. Set `job-summary:
+"false"` to disable the summary. `steps.evalforge.outputs.exit-code` exposes the
+gate status for later steps using `if: always()`. Exit 2 means invalid input;
+no evaluation report is promised in that case. Pin EvalForge's full release
+commit SHA when adopting it in a production workflow.
+
+## Audit a decision
+
+JSON, JUnit, SARIF, and Markdown carry the same evidence identities. The JSON
+`evidence` object includes producer name/version, source revision, and SHA-256
+digests of the normalized candidate, baseline, and policy. Artifact digests use
+`model_dump(mode="json", by_alias=True, exclude_none=True)`; policy digests use
+`model_dump(mode="json", by_alias=True)` including defaults. Both use sorted
+JSON keys, compact separators, UTF-8, `ensure_ascii=False`, and no non-finite
+numbers (`evalforge.canonical-json.v1`). Whitespace and key order in the original
+file do not change the digest. Metric values normalize to floats.
+
+Digests identify inputs; they are not cryptographic signatures or proof of who
+created an artifact. Keep the artifacts and policy with the report to reproduce
+the decision. The gate reports do not copy arbitrary artifact metadata.
+
+## Evaluator contracts
+
+- [promptfoo schema-v3 mapping](INTEROPERABILITY.md#promptfoo-adapter)
+- [Ragas selected score columns](integrations/ragas.md)
+- [DeepEval version-aware metric mapping](integrations/deepeval.md)
+
+The fixtures demonstrate format compatibility with synthetic data. They are not
+evidence of downstream adoption, model quality, or independently measured usage.

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -35,12 +35,18 @@ On 2026-08-31, the repository reached 48 GitHub stars. Public GitHub data still 
 
 Later on 2026-08-31, the public repository reached 50 GitHub stars. It still had zero forks, zero external contributors, and zero confirmed downstream adopters; the only open pull request was an automated Dependabot update. The milestone is recorded as early interest only and does not change the project's adoption claims.
 
+On 2026-09-10 at 11:05 UTC, the [public GitHub repository API](https://api.github.com/repos/jsdhwfmax/EvalForge) reported 177 stars and zero forks. The [contributors endpoint](https://api.github.com/repos/jsdhwfmax/EvalForge/contributors) listed one contributor, the primary maintainer. There were [four public GitHub releases](https://github.com/jsdhwfmax/EvalForge/releases), including two marked prerelease; the latest was v0.3.1. The [PyPI project](https://pypi.org/project/evalforge-ci/0.3.1/) exposed the 0.3.1 distribution. No independent downstream adopter had been verified for `ADOPTERS.md`. These are dated observations, not live counts or evidence of production adoption.
+
+The package-publication milestone is therefore complete. The harder next step is demonstrating that another maintainer can integrate EvalForge, understand a failed gate, and keep using it as their evaluator changes. Adapter fixtures, complete CI examples, comparison safeguards, and reports that identify their input evidence support that work. They are engineering deliverables, not substitutes for independently confirmed use.
+
+See [OSS readiness and evidence](OSS_READINESS.md) for the current application rationale and the limits of each evidence category.
+
 ## Twelve-month success criteria
 
-1. Publish the uniquely named `evalforge-ci` distribution with reproducible releases.
+1. Maintain the published `evalforge-ci` distribution with verified wheel/source releases, installation checks, and documented compatibility.
 2. Land at least three external evaluator adapters backed by upstream fixtures.
 3. Document at least five independent downstream repositories in an adopters file with maintainer consent.
 4. Maintain schema compatibility and a public changelog across at least four releases.
 5. Respond to security and correctness reports within the targets in `SECURITY.md`.
 
-These are project goals, not present-tense claims.
+Publication of `evalforge-ci` has been verified. The remaining targets are project goals, not present-tense claims.

--- a/docs/INTEROPERABILITY.md
+++ b/docs/INTEROPERABILITY.md
@@ -68,6 +68,14 @@ mapping before treating a custom named score as stable release evidence.
 
 ## Gate policy v1
 
+Ragas and DeepEval use separate opt-in commands; their exact mappings,
+supported formats, and fixture provenance are documented in the
+[Ragas integration](integrations/ragas.md) and
+[DeepEval integration](integrations/deepeval.md). All import commands accept
+`--dataset-fingerprint` and `--metric-version`. The latter must identify the
+actual metric/judge configuration; an adapter mapping version alone does not
+describe the measurement's semantics.
+
 The normative schema is [`schemas/gate-policy-v1.schema.json`](../schemas/gate-policy-v1.schema.json).
 
 Each check names a metric, comparison, threshold, and severity:
@@ -83,11 +91,25 @@ Evidence values and policy thresholds must be finite numbers. `NaN`, positive in
 
 For baseline-delta checks, the candidate and baseline must declare the same unit and metric direction. EvalForge fails the check as a configuration error rather than subtracting values with incompatible semantics.
 
+The optional `comparison` object can enable `require_same_dataset`,
+`require_same_producer`, and `require_same_metric_version` (all default false).
+These require a baseline and matching non-empty identity declarations, and
+apply to every check in the policy. See the [CI cookbook](CI_COOKBOOK.md) for
+precise semantics and a reproducible failure case. Finite inputs whose delta
+overflows also produce an error. Canonical numeric fields reject booleans and
+numeric strings, matching the published JSON Schemas.
+
 ## Reports
 
 - JSON preserves every evaluated value and message for automation.
 - JUnit represents each policy check as a test case for test-report viewers.
 - SARIF represents failed and warning checks as static-analysis results for code scanning interfaces.
+- Markdown provides a job summary with values, failures, source revisions, and input digests.
+
+Every report includes the same evidence identity and normalized-input SHA-256
+digests. The [digest contract](CI_COOKBOOK.md#audit-a-decision) specifies
+canonicalization and its limits. Reports omit arbitrary artifact metadata;
+producer/run fields and valid string identities are intentionally retained.
 
 SARIF results are run-level findings and intentionally omit a fabricated source location. Consumers should link the report to the evaluation artifact and source revision.
 

--- a/docs/OSS_READINESS.md
+++ b/docs/OSS_READINESS.md
@@ -1,0 +1,58 @@
+# OSS readiness and evidence
+
+EvalForge is an early MIT-licensed project for turning evaluator output into reviewable CI release decisions. Its application case rests on a concrete interoperability problem and inspectable maintenance work. Broad adoption has not been established.
+
+## Official program alignment
+
+Checked on 2026-09-10:
+
+- [Codex for Open Source](https://learn.chatgpt.com/community/codex-for-oss) invites core maintainers and widely used public projects to apply. A project outside those categories may still explain its ecosystem importance. The page publishes no minimum star count.
+- The [program terms](https://learn.chatgpt.com/docs/codex-for-oss-terms) require a valid ChatGPT account and accurate information about the applicant, repositories, and maintenance role. Review may consider usage, ecosystem importance, active maintenance, permissions, and program capacity; affiliation or control may need verification.
+- Selection and benefits are discretionary. API credits and Codex Security may require additional review, and repository access must be authorized.
+
+This is an evidence map, not a claim of acceptance or a replacement for the current application form and terms.
+
+## Public evidence snapshot
+
+The following public endpoints were checked on **2026-09-10 at 11:05 UTC**. They are live sources; their values can change after this dated snapshot.
+
+| Category | Verified observation | Source and limit |
+|---|---|---|
+| Public source and license | `jsdhwfmax/EvalForge`, MIT | [Repository](https://github.com/jsdhwfmax/EvalForge) and [license](../LICENSE) |
+| Maintenance responsibility | One named primary maintainer | [MAINTAINERS.md](../MAINTAINERS.md); program reviewers may separately verify repository permissions |
+| Interest | 177 GitHub stars | [Repository API](https://api.github.com/repos/jsdhwfmax/EvalForge); interest does not establish use |
+| Forks | 0 | Same repository endpoint; no adoption claim follows from this count |
+| Contributors | GitHub's endpoint listed only `jsdhwfmax` | [Contributors API](https://api.github.com/repos/jsdhwfmax/EvalForge/contributors); this does not capture every kind of community contribution |
+| Released source | Four GitHub releases, two marked prerelease; latest v0.3.1 | [Releases](https://github.com/jsdhwfmax/EvalForge/releases) |
+| Python distribution | `evalforge-ci` 0.3.1 available on PyPI | [Exact package version](https://pypi.org/project/evalforge-ci/0.3.1/); this observation is package availability, not a new installation test |
+| Independent adoption | None verified for the adopters record | [ADOPTERS.md](../ADOPTERS.md); absence from this record does not prove nobody uses the package |
+| Quality evidence | Test code and CI/release workflows are public | [Tests](../tests), [CI](../.github/workflows/ci.yml), [release workflow](../.github/workflows/release.yml); a workflow definition alone does not prove a run passed |
+
+The v0.4.0 upgrade is separate from this pre-upgrade snapshot. Any claim that v0.4.0 is published, installed successfully, or passing CI must cite its actual release and verification results after they exist.
+
+## Why the project can matter
+
+An evaluator answers how a system scored. A release gate must also answer which evidence was compared, what policy was enforced, and why a release passed or failed. EvalForge keeps that boundary small: aggregate artifacts, explicit policies, and reports consumed by existing CI tools. It can be used without running an EvalForge service or sending a private golden dataset to one.
+
+The strongest demonstration is a complete, reproducible integration: import a supported evaluator's sanitized output, compare it with the intended baseline, fail a policy for a known regression, and retain reports that explain the decision. [Interoperability](INTEROPERABILITY.md) documents the supported formats and semantic boundaries. Adapters complement existing evaluators; they do not establish that an evaluator's metric is scientifically valid.
+
+For baseline checks, unit agreement alone is insufficient. Dataset identity, producer identity, and metric-implementation version are useful comparison constraints when the producer supplies them. These safeguards must have explicit behavior for missing or incompatible evidence and retain a documented path for simple flat summaries.
+
+## Maintenance work the program could support
+
+- Review schema, adapter, and policy changes against compatibility fixtures.
+- Triage reproducible issues and turn regressions into tests.
+- Review input parsing, report rendering, dependency changes, and the release supply chain.
+- Maintain versioned adapter mappings and executable CI examples.
+- Prepare release notes and verify distributions before publishing.
+
+The maintainer remains responsible for review and release decisions. Sanitized fixtures and public source are sufficient for this maintenance work; private user datasets are not needed in application materials.
+
+## What remains to demonstrate
+
+1. A public integration in an independently maintained repository, linked and listed with that maintainer's consent.
+2. Feedback showing whether another maintainer can install the package, understand a failed check, and maintain its policy.
+3. Sustained compatibility across evaluator versions and several maintenance releases.
+4. Measured outcomes, such as a documented regression caught or maintenance time saved, with the method and source attached.
+
+These are evidence gaps and project goals. They cannot be filled by stars, synthetic users, a new README claim, or a local demonstration labeled as production use. For the application, describe the present engineering contribution and these limits together.

--- a/docs/PORTFOLIO.md
+++ b/docs/PORTFOLIO.md
@@ -1,16 +1,25 @@
 # Portfolio and resume notes
 
-Use only claims that remain true for the published repository and deployed environment.
+Use only claims that remain true for the exact published version being discussed. Link to its source, release files, and successful checks; do not describe a local change as a published feature or a deployment blueprint as a running service.
 
 ## Resume bullet (English)
 
-> Built and open-sourced EvalForge, an evaluator-neutral evidence and quality-gate layer for AI systems that converts JSON metrics into baseline-aware policies, JSON, JUnit, and SARIF; also shipped a zero-key RAG reference evaluator with dataset fingerprints, a FastAPI/PostgreSQL API, 39 tests (87.68% coverage), Docker Compose, GitHub Actions, and a Streamlit release dashboard.
+> Built and open-sourced EvalForge, an evaluator-neutral evidence and quality-gate layer for AI systems that converts JSON metrics into baseline-aware policies and JSON, JUnit, and SARIF reports. Published the `evalforge-ci` Python package and reusable GitHub Action, with a zero-key RAG reference evaluator, dataset fingerprints, a FastAPI API, PostgreSQL support, and a Streamlit comparison dashboard.
+
+Verification: [published releases](https://github.com/jsdhwfmax/EvalForge/releases), [PyPI](https://pypi.org/project/evalforge-ci/), [test suite](../tests), and [CI workflow](../.github/workflows/ci.yml). Test counts and coverage belong to a specific commit and run; cite that result when needed instead of carrying an outdated number in a resume bullet.
 
 ## Measured follow-up bullet
 
 > Designed a reproducible five-question RAG benchmark that exposed a retrieval-generation trade-off: increasing context from BM25 top-1 to hybrid top-3 improved Recall@K from 90% to 100% while reducing extractive answer token-F1 from 75.92% to 54.85%, demonstrating the need for multi-dimensional release gates.
 
 These numbers describe the committed synthetic demo dataset and deterministic local provider, not a production LLM.
+
+## Evidence and scope
+
+- The [benchmark methodology](BENCHMARK.md) explains the five-question demonstration and its limitations.
+- The [artifact and policy specification](INTEROPERABILITY.md) defines the supported interchange and gate behavior.
+- [OSS readiness](OSS_READINESS.md) separates delivered engineering work, verified public activity, and adoption evidence that remains missing.
+- The project is early. Stars measure interest; do not claim production users, independent adopters, broad ecosystem adoption, or maintainer time saved without a public source that establishes the claim.
 
 ## 中文项目描述
 
@@ -27,3 +36,5 @@ These numbers describe the committed synthetic demo dataset and deterministic lo
 - Why a dataset fingerprint is required before treating two experiment deltas as comparable.
 - How JUnit output lets an LLM-specific gate fit standard SDET and CI tooling.
 - Why evaluator-neutral artifacts let maintainers change measurement tools without rewriting release policy.
+- Why a matching metric name and unit alone cannot establish that two evaluations used the same dataset and metric implementation.
+- How to preserve aggregate release evidence while excluding raw prompts, responses, and private test data from evaluator imports.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -7,7 +7,7 @@ EvalForge releases should leave public, reproducible evidence that the tagged so
 3. Install the built wheel in a fresh environment and run the committed quality-gate example.
 4. Confirm main-branch CI, CodeQL, and all dependency update checks are green.
 5. Before the first PyPI release, create a protected GitHub environment named `pypi` and configure a PyPI pending Trusted Publisher with owner `jsdhwfmax`, repository `EvalForge`, workflow `release.yml`, and environment `pypi`. Do not create an API token.
-6. Confirm `https://pypi.org/pypi/evalforge-ci/json` still returns 404 before registering the pending publisher. Stop if another owner has claimed the distribution name.
+6. For the first registration only, confirm `https://pypi.org/pypi/evalforge-ci/json` returns 404 before registering the pending publisher; stop if another owner has claimed the name. The package is now published. For subsequent releases, verify the existing project's Trusted Publisher still matches this repository, workflow, and environment, and confirm the new version is not already published. Do not try to overwrite an existing PyPI release.
 7. Create a signed or GitHub-verified tag and publish release notes that state compatibility and known limitations.
 8. Verify the release workflow attached the wheel, source distribution, and `SHA256SUMS` file and completed the `pypi-publish` job through OIDC.
 9. Verify the exact release from an unauthenticated environment with `python -m pip install --no-cache-dir 'evalforge-ci==<version>'`, then run `evalforge --help` and the committed gate example.

--- a/docs/integrations/deepeval.md
+++ b/docs/integrations/deepeval.md
@@ -1,0 +1,131 @@
+# Import DeepEval evaluation evidence
+
+EvalForge imports a local JSON serialization of DeepEval's `EvaluationResult`
+into aggregate evidence for policy gates. DeepEval does not need to be installed
+in the environment importing or gating the artifact.
+
+The supported producer versions are **3.8.1 and 4.2.2**, each verified against a
+fixed upstream tag and the installed package. Other versions are rejected until
+their export shape and metric semantics are verified. The import contract is
+`EvaluationResult.model_dump(mode="json", by_alias=False)`, which contains a
+`test_results` array with `name`, `success`, `conversational`, and `metrics_data`
+on each row. It is not DeepEval's `TestRun`/`.latest_run_full.json` format or a
+Confident AI API response. See the pinned
+[types for 4.2.2](https://github.com/confident-ai/deepeval/blob/f94d940c1e5afc4b280420fe73fe17d146274018/deepeval/evaluate/types.py)
+and [fixture provenance](../../tests/fixtures/deepeval/README.md).
+
+## Export and import
+
+Save the result of an existing evaluation in the environment that ran DeepEval:
+
+```python
+import json
+from importlib.metadata import version
+from pathlib import Path
+
+# result is the EvaluationResult returned by your existing evaluate(...) call.
+Path("deepeval-results.json").write_text(
+    json.dumps(result.model_dump(mode="json", by_alias=False), allow_nan=False),
+    encoding="utf-8",
+)
+print(version("deepeval"))  # Pass this exact installed version to the importer.
+```
+
+The export contains raw evaluation content. Keep it in your evaluation
+environment; publish the aggregate artifact if that is the intended evidence.
+Importing the export makes no model or network calls:
+
+```bash
+evalforge import deepeval deepeval-results.json \
+  --producer-version 4.2.2 \
+  --source-revision YOUR_GIT_COMMIT \
+  --dataset-fingerprint sha256:YOUR_DATASET_DIGEST \
+  --metric-version YOUR_JUDGE_AND_METRIC_CONFIG_DIGEST \
+  --output deepeval-artifact.json
+evalforge gate deepeval-artifact.json --policy examples/deepeval_policy.json
+```
+
+`--metric-version` is a caller-supplied identity for the actual judge and metric
+configuration, including relevant prompts, parameters, and thresholds. The
+adapter mapping version only identifies import code; it is not a substitute for
+that configuration identity. Dataset fingerprints and source revisions also come
+from explicit arguments, never arbitrary fields in the source export.
+
+Python callers can use the same importer:
+
+```python
+from pathlib import Path
+from evalforge.adapters.deepeval import load_deepeval_export
+from evalforge.artifacts import write_artifact
+
+artifact = load_deepeval_export(
+    Path("deepeval-results.json"),
+    producer_version="4.2.2",
+    source_revision="YOUR_GIT_COMMIT",
+    dataset_fingerprint="sha256:YOUR_DATASET_DIGEST",
+)
+artifact.metadata["metric_version"] = "YOUR_JUDGE_AND_METRIC_CONFIG_DIGEST"
+write_artifact(Path("deepeval-artifact.json"), artifact)
+```
+
+## Metrics and direction
+
+`test_cases` counts result rows. `deepeval_pass_rate` divides passing rows by
+**all** rows. Every exported score is the arithmetic mean over that same complete
+suite. The importer uses this fixed allowlist of exact built-in display names:
+
+| DeepEval name | Artifact metric | Direction |
+| --- | --- | --- |
+| Answer Relevancy | `deepeval_answer_relevancy` | higher |
+| Faithfulness | `deepeval_faithfulness` | higher |
+| Contextual Precision | `deepeval_contextual_precision` | higher |
+| Contextual Recall | `deepeval_contextual_recall` | higher |
+| Contextual Relevancy | `deepeval_contextual_relevancy` | higher |
+| Tool Correctness | `deepeval_tool_correctness` | higher |
+| Task Completion | `deepeval_task_completion` | higher |
+| Hallucination (3.8.1) | `deepeval_v3_hallucination` | lower |
+| Bias (3.8.1) | `deepeval_v3_bias` | lower |
+| Toxicity (3.8.1) | `deepeval_v3_toxicity` | lower |
+| Hallucination (4.2.2) | `deepeval_v4_hallucination` | higher |
+| Bias (4.2.2) | `deepeval_v4_bias` | higher |
+| Toxicity (4.2.2) | `deepeval_v4_toxicity` | higher |
+
+DeepEval's `MetricData` has no direction field. The mapping is derived from the
+pinned metric implementations. In 3.8.1, Hallucination measures contradictory
+contexts; in 4.2.2 it measures aligned contexts. Bias and Toxicity also reversed
+score meaning. These three metrics use separate names across versions so a gate
+cannot accidentally reuse a threshold or baseline with the opposite meaning.
+Scores are preserved, not inverted by the adapter. Sources:
+[3.8.1 Hallucination](https://github.com/confident-ai/deepeval/blob/fc268fa3fc04e0f5ebb25db3631788913c02b38a/deepeval/metrics/hallucination/hallucination.py),
+[4.2.2 Hallucination](https://github.com/confident-ai/deepeval/blob/f94d940c1e5afc4b280420fe73fe17d146274018/deepeval/metrics/hallucination/hallucination.py),
+[4.2.2 Bias](https://github.com/confident-ai/deepeval/blob/f94d940c1e5afc4b280420fe73fe17d146274018/deepeval/metrics/bias/bias.py),
+[4.2.2 Toxicity](https://github.com/confident-ai/deepeval/blob/f94d940c1e5afc4b280420fe73fe17d146274018/deepeval/metrics/toxicity/toxicity.py).
+
+Custom metric names are not copied or converted to slugs. Their verdicts still
+participate in the overall pass rate, and their numeric/error fields still must
+be valid. An export containing only custom metrics produces sample count and
+pass rate. Do not give a custom implementation a built-in display name with
+different semantics; this file format cannot authenticate metric code.
+
+## Validation and privacy
+
+Each result must contain the same nonempty metric suite with no duplicate names.
+Every score and threshold must be a finite number, and every success value must
+be a boolean. Missing/null/non-finite scores, errored metrics, score-only metrics,
+flaky metrics, mixed conversation modes, and inconsistent verdicts fail the
+import. Built-in scores and thresholds must be in `[0, 1]`, and their verdicts must
+match the versioned threshold rule. Custom metric threshold rules are not
+inferred. A failed import never produces a partially averaged artifact. The
+adapter cannot detect test cases removed before export; set a minimum
+`test_cases` gate and compare a trusted dataset fingerprint.
+
+The artifact excludes test names, inputs, outputs, expected outputs, contexts,
+turns, reasons, traces, logs, model identifiers, costs, arbitrary metric names,
+metadata, Confident AI links, and run IDs from the export. Error messages use
+structural positions rather than quoting raw values. Caller-supplied revision,
+dataset, and metric-configuration identifiers are retained intentionally.
+
+The example policy targets 4.2.2 and uses illustrative thresholds. Its v4
+Hallucination check fails with missing evidence on a 3.8.1 artifact rather than
+silently treating the old score as equivalent. The offline fixtures are
+synthetic contract tests; they do not demonstrate the quality of an LLM.

--- a/docs/integrations/ragas.md
+++ b/docs/integrations/ragas.md
@@ -1,0 +1,115 @@
+# Import Ragas scores into a CI gate
+
+EvalForge imports the JSON records produced by an existing
+`EvaluationResult.to_pandas().to_json(orient="records")` export. The adapter runs
+locally and needs neither Ragas nor pandas installed. It does not call a model.
+
+## Export from your evaluation environment
+
+After your Ragas evaluation has finished, save its per-sample table:
+
+```python
+from importlib.metadata import version
+
+result.to_pandas().to_json("ragas-results.json", orient="records")
+print(version("ragas"))  # Supply this actual version to the importer.
+```
+
+This export contains both sample content and score columns. It has no producer
+version or dataset identity. Keep the raw file in your evaluation environment;
+the imported artifact contains only the selected aggregate scores, sample count,
+and explicit provenance. Review artifact names and provenance before sharing.
+
+## Run the included example
+
+From an EvalForge checkout with the CLI installed:
+
+```bash
+evalforge import ragas tests/fixtures/ragas/evaluation-result-records.json \
+  --producer-version 0.2.12 \
+  --metric faithfulness \
+  --metric answer_relevancy \
+  --source-revision example-revision \
+  --dataset-fingerprint synthetic-ragas-fixture-v1 \
+  --output artifacts/ragas.json
+
+evalforge gate artifacts/ragas.json \
+  --policy examples/ragas_policy.json \
+  --json artifacts/ragas-gate.json \
+  --junit artifacts/ragas-gate.xml \
+  --sarif artifacts/ragas-gate.sarif
+```
+
+The fixture has two synthetic samples: mean `faithfulness` is `0.75` and mean
+`answer_relevancy` is `0.9`. The example policy passes. Its thresholds and minimum
+of two samples demonstrate the workflow; set thresholds and a useful sample
+minimum for your own application before using it for releases.
+
+For your own export, replace the fixture path, version, metric columns, revision,
+and fingerprint. The fingerprint should identify the evaluation dataset, not the
+whole results file, whose responses and scores change between runs. EvalForge
+records the provided fingerprint; it does not verify or derive one from raw data.
+
+## Mapping and failure behavior
+
+| Input | Portable artifact |
+| --- | --- |
+| Each repeated `--metric COLUMN` | Arithmetic mean under the original column name |
+| Number of records | `test_cases`, with unit `count` |
+| `--producer-version` | `producer.name = ragas`, with the supplied version |
+| Optional `--source-revision` | `run.source_revision` |
+| Optional `--dataset-fingerprint` | `metadata.dataset_fingerprint` |
+
+Every selected metric must be a finite JSON number on **every** row. Missing
+columns, `null`, booleans, numeric strings, non-finite values, duplicate JSON keys,
+non-object rows, and empty exports fail the import. A failed evaluation row is
+never silently removed to raise the mean. Fix or rerun the failed evaluation
+before exporting again. Unselected columns are not imported or aggregated.
+
+Column selection is mandatory because numeric sample fields are not necessarily
+scores. Known dataset field names, such as `response` and `reference`, are
+reserved, and `test_cases` is reserved for the actual sample count. Other custom
+score columns are supported when explicitly selected.
+
+Selected metrics use unit `score` and direction `neutral`; the gate policy sets
+the comparison operator. The adapter does not equate a Ragas metric with a
+similarly named EvalForge metric or assume every custom score is a ratio.
+Compare results evaluated with the same metric configuration, model, dataset,
+and aggregation. The artifact records mapping version `1`, source format
+`ragas.evaluation_result.pandas.records`, selected columns, and aggregation
+`mean`. It carries no prompts, responses, retrieved contexts, traces, source
+metadata, or unselected scores.
+
+## Python API
+
+```python
+from pathlib import Path
+
+from evalforge.adapters.ragas import load_ragas_export
+from evalforge.artifacts import write_artifact
+
+artifact = load_ragas_export(
+    Path("ragas-results.json"),
+    producer_version="0.2.12",  # Use the version that produced your result.
+    metrics=["faithfulness", "answer_relevancy"],
+    source_revision="your-source-revision",
+    dataset_fingerprint="your-dataset-fingerprint",
+)
+write_artifact(Path("artifacts/ragas.json"), artifact)
+```
+
+## Supported format and verification
+
+This adapter accepts a JSON **array of records**, not a Python `repr(result)`,
+JSONL, CSV, pandas' default column-oriented JSON, or a Ragas experiment/backend
+export. Those formats have different contracts and are rejected rather than
+guessed. Producer version is caller-supplied provenance because records JSON
+does not embed it.
+
+The serialization contract was verified against the
+[Ragas 0.2.12 source](https://github.com/vibrantlabsai/ragas/blob/f5bc2b5e7628f5c68d824e085c4edc17840080b1/src/ragas/dataset_schema.py)
+and [pandas records JSON documentation](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html).
+See [fixture provenance](../../tests/fixtures/ragas/README.md) for the exact
+verification method and its limits. Compatibility with other versions depends
+on preserving this same export shape; it is not a claim of exhaustive SDK
+version testing.

--- a/examples/deepeval_policy.json
+++ b/examples/deepeval_policy.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jsdhwfmax/EvalForge/main/schemas/gate-policy-v1.schema.json",
+  "version": 1,
+  "name": "DeepEval 4.2.2 example release gate",
+  "checks": [
+    {
+      "id": "deepeval-sample-count",
+      "metric": "test_cases",
+      "op": "gte",
+      "value": 3,
+      "description": "Require at least three complete test results in this example"
+    },
+    {
+      "id": "deepeval-pass-rate",
+      "metric": "deepeval_pass_rate",
+      "op": "gte",
+      "value": 0.6,
+      "description": "At least 60% of test results must pass every metric"
+    },
+    {
+      "id": "deepeval-answer-relevancy",
+      "metric": "deepeval_answer_relevancy",
+      "op": "gte",
+      "value": 0.7,
+      "description": "Mean DeepEval Answer Relevancy must be at least 0.7"
+    },
+    {
+      "id": "deepeval-context-alignment",
+      "metric": "deepeval_v4_hallucination",
+      "op": "gte",
+      "value": 0.6,
+      "description": "DeepEval 4 Hallucination is higher-is-better context alignment"
+    }
+  ]
+}

--- a/examples/ragas_policy.json
+++ b/examples/ragas_policy.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jsdhwfmax/EvalForge/main/schemas/gate-policy-v1.schema.json",
+  "version": 1,
+  "name": "Ragas score gate",
+  "checks": [
+    {
+      "id": "ragas-faithfulness",
+      "metric": "faithfulness",
+      "op": "gte",
+      "value": 0.7,
+      "description": "Mean faithfulness must be at least 0.7"
+    },
+    {
+      "id": "ragas-answer-relevancy",
+      "metric": "answer_relevancy",
+      "op": "gte",
+      "value": 0.8,
+      "description": "Mean answer relevancy must be at least 0.8"
+    },
+    {
+      "id": "ragas-sample-count",
+      "metric": "test_cases",
+      "op": "gte",
+      "value": 2,
+      "description": "The synthetic demonstration must contain at least two samples"
+    }
+  ]
+}

--- a/examples/strict-comparison/baseline.json
+++ b/examples/strict-comparison/baseline.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0",
+  "producer": {
+    "name": "example-evaluator",
+    "version": "1.0.0"
+  },
+  "run": {
+    "id": "baseline",
+    "source_revision": "baseline-demo"
+  },
+  "metrics": {
+    "quality": {
+      "value": 0.88,
+      "unit": "ratio",
+      "direction": "higher"
+    }
+  },
+  "metadata": {
+    "dataset_fingerprint": "synthetic-set-v1",
+    "metric_version": "example-score-v1"
+  }
+}

--- a/examples/strict-comparison/candidate.json
+++ b/examples/strict-comparison/candidate.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0",
+  "producer": {
+    "name": "example-evaluator",
+    "version": "1.0.0"
+  },
+  "run": {
+    "id": "candidate",
+    "source_revision": "candidate-demo"
+  },
+  "metrics": {
+    "quality": {
+      "value": 0.91,
+      "unit": "ratio",
+      "direction": "higher"
+    }
+  },
+  "metadata": {
+    "dataset_fingerprint": "synthetic-set-v1",
+    "metric_version": "example-score-v1"
+  }
+}

--- a/examples/strict-comparison/changed-dataset.json
+++ b/examples/strict-comparison/changed-dataset.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0",
+  "producer": {
+    "name": "example-evaluator",
+    "version": "1.0.0"
+  },
+  "run": {
+    "id": "changed-dataset",
+    "source_revision": "candidate-demo"
+  },
+  "metrics": {
+    "quality": {
+      "value": 0.99,
+      "unit": "ratio",
+      "direction": "higher"
+    }
+  },
+  "metadata": {
+    "dataset_fingerprint": "synthetic-set-v2",
+    "metric_version": "example-score-v1"
+  }
+}

--- a/examples/strict-comparison/policy.json
+++ b/examples/strict-comparison/policy.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "name": "Comparable release evidence",
+  "comparison": {
+    "require_same_dataset": true,
+    "require_same_producer": true,
+    "require_same_metric_version": true
+  },
+  "checks": [
+    {
+      "id": "quality-floor",
+      "metric": "quality",
+      "op": "gte",
+      "value": 0.85
+    },
+    {
+      "id": "quality-regression",
+      "metric": "quality",
+      "op": "delta_gte",
+      "value": -0.02
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "evalforge-ci"
-version = "0.3.1"
+version = "0.4.0"
 description = "Portable evaluation evidence and policy gates for RAG and AI assistants"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/schemas/gate-policy-v1.schema.json
+++ b/schemas/gate-policy-v1.schema.json
@@ -4,28 +4,82 @@
   "title": "EvalForge Gate Policy v1",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version", "checks"],
+  "required": [
+    "version",
+    "checks"
+  ],
   "properties": {
-    "$schema": {"type": "string"},
-    "version": {"const": 1},
-    "name": {"type": "string", "minLength": 1},
+    "$schema": {
+      "type": "string"
+    },
+    "version": {
+      "const": 1
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
     "checks": {
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["id", "metric", "op", "value"],
+        "required": [
+          "id",
+          "metric",
+          "op",
+          "value"
+        ],
         "properties": {
           "id": {
             "type": "string",
             "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
           },
-          "metric": {"type": "string", "minLength": 1},
-          "op": {"enum": ["gte", "lte", "delta_gte", "delta_lte"]},
-          "value": {"type": "number"},
-          "severity": {"enum": ["error", "warning"], "default": "error"},
-          "description": {"type": "string", "default": ""}
+          "metric": {
+            "type": "string",
+            "minLength": 1
+          },
+          "op": {
+            "enum": [
+              "gte",
+              "lte",
+              "delta_gte",
+              "delta_lte"
+            ]
+          },
+          "value": {
+            "type": "number"
+          },
+          "severity": {
+            "enum": [
+              "error",
+              "warning"
+            ],
+            "default": "error"
+          },
+          "description": {
+            "type": "string",
+            "default": ""
+          }
+        }
+      }
+    },
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "require_same_dataset": {
+          "type": "boolean",
+          "default": false
+        },
+        "require_same_producer": {
+          "type": "boolean",
+          "default": false
+        },
+        "require_same_metric_version": {
+          "type": "boolean",
+          "default": false
         }
       }
     }

--- a/src/evalforge/__init__.py
+++ b/src/evalforge/__init__.py
@@ -1,3 +1,3 @@
 """EvalForge: portable evaluation evidence and quality gates for AI systems."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/src/evalforge/adapters/deepeval.py
+++ b/src/evalforge/adapters/deepeval.py
@@ -1,0 +1,238 @@
+"""Import explicitly supported DeepEval EvaluationResult JSON exports offline."""
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple
+
+from evalforge.artifacts import (
+    ArtifactProducer,
+    ArtifactRun,
+    EvaluationArtifact,
+    MetricValue,
+)
+
+ADAPTER_MAPPING_VERSION = "1"
+SUPPORTED_VERSIONS = {
+    "3.8.1": "fc268fa3fc04e0f5ebb25db3631788913c02b38a",
+    "4.2.2": "f94d940c1e5afc4b280420fe73fe17d146274018",
+}
+
+# These are exact upstream built-in display names, not user-controlled slugs.
+# Unknown names are validated but never included in artifacts or diagnostics.
+_COMMON_METRICS = {
+    "Answer Relevancy": "deepeval_answer_relevancy",
+    "Faithfulness": "deepeval_faithfulness",
+    "Contextual Precision": "deepeval_contextual_precision",
+    "Contextual Recall": "deepeval_contextual_recall",
+    "Contextual Relevancy": "deepeval_contextual_relevancy",
+    "Tool Correctness": "deepeval_tool_correctness",
+    "Task Completion": "deepeval_task_completion",
+}
+_REVERSED_METRICS = {
+    "Hallucination": "hallucination",
+    "Bias": "bias",
+    "Toxicity": "toxicity",
+}
+Direction = Literal["higher", "lower"]
+
+
+def _object(value: Any, path: str) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("DeepEval %s must be a JSON object" % path)
+    return value
+
+
+def _nonempty_string(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("DeepEval %s must be a non-empty string" % path)
+    return value
+
+
+def _boolean(value: Any, path: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError("DeepEval %s must be a boolean" % path)
+    return value
+
+
+def _finite_number(value: Any, path: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("DeepEval %s must be a finite number" % path)
+    try:
+        number = float(value)
+    except OverflowError as exc:
+        raise ValueError("DeepEval %s must be a finite number" % path) from exc
+    if not math.isfinite(number):
+        raise ValueError("DeepEval %s must be a finite number" % path)
+    return number
+
+
+def _metric_mapping(producer_version: str) -> Dict[str, Tuple[str, Direction]]:
+    mapping: Dict[str, Tuple[str, Direction]] = {
+        name: (target, "higher") for name, target in _COMMON_METRICS.items()
+    }
+    legacy = producer_version == "3.8.1"
+    for name, suffix in _REVERSED_METRICS.items():
+        # DeepEval reversed all three scores in v4. Separate names prevent a
+        # historical lower-is-better score from becoming a v4 gate baseline.
+        mapping[name] = (
+            "deepeval_v%s_%s" % ("3" if legacy else "4", suffix),
+            "lower" if legacy else "higher",
+        )
+    return mapping
+
+
+def deepeval_artifact_from_export(
+    payload: Dict[str, Any],
+    *,
+    producer_version: str,
+    source_revision: Optional[str] = None,
+    dataset_fingerprint: Optional[str] = None,
+) -> EvaluationArtifact:
+    """Convert ``EvaluationResult.model_dump(mode='json', by_alias=False)``.
+
+    Only DeepEval 3.8.1 and 4.2.2 are verified. Each row must contain the same
+    nonempty metric suite, with finite scores and explicit pass/fail verdicts.
+    Score-only, errored, and flaky metrics are rejected. The built-in name
+    allowlist controls score export; custom names and all raw content stay local.
+    """
+
+    version = _nonempty_string(producer_version, "producer_version")
+    if version not in SUPPORTED_VERSIONS:
+        raise ValueError("DeepEval producer_version must be a verified version: 3.8.1 or 4.2.2")
+    if source_revision is not None:
+        _nonempty_string(source_revision, "source_revision")
+    if dataset_fingerprint is not None:
+        _nonempty_string(dataset_fingerprint, "dataset_fingerprint")
+
+    root = _object(payload, "export")
+    rows = root.get("test_results")
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("DeepEval test_results must be a non-empty JSON array")
+
+    mapping = _metric_mapping(version)
+    suite: Optional[Set[str]] = None
+    conversational: Optional[bool] = None
+    scores: Dict[str, List[float]] = {}
+    successes = 0
+    for index, raw_row in enumerate(rows):
+        row_path = "test_results[%s]" % index
+        row = _object(raw_row, row_path)
+        _nonempty_string(row.get("name"), row_path + ".name")
+        success = _boolean(row.get("success"), row_path + ".success")
+        row_conversational = _boolean(row.get("conversational"), row_path + ".conversational")
+        if conversational is not None and conversational != row_conversational:
+            raise ValueError("DeepEval test_results must use one conversation mode")
+        conversational = row_conversational
+        metric_rows = row.get("metrics_data")
+        if not isinstance(metric_rows, list) or not metric_rows:
+            raise ValueError("DeepEval %s.metrics_data must be a non-empty JSON array" % row_path)
+
+        names: Set[str] = set()
+        metric_successes: List[bool] = []
+        for metric_index, raw_metric in enumerate(metric_rows):
+            metric_path = "%s.metrics_data[%s]" % (row_path, metric_index)
+            metric = _object(raw_metric, metric_path)
+            name = _nonempty_string(metric.get("name"), metric_path + ".name")
+            if name in names:
+                raise ValueError("DeepEval %s contains a duplicate metric name" % row_path)
+            names.add(name)
+            if metric.get("error") is not None:
+                raise ValueError("DeepEval %s contains an errored metric" % metric_path)
+            # A flaky failure can legitimately leave TestResult.success=True.
+            # It needs a different gate policy; do not silently ignore it here.
+            flaky = _boolean(metric.get("flaky", False), metric_path + ".flaky")
+            if flaky:
+                raise ValueError("DeepEval %s contains an unsupported flaky metric" % metric_path)
+            score = _finite_number(metric.get("score"), metric_path + ".score")
+            threshold = _finite_number(metric.get("threshold"), metric_path + ".threshold")
+            metric_success = _boolean(metric.get("success"), metric_path + ".success")
+            metric_successes.append(metric_success)
+
+            if name not in mapping:
+                continue
+            if not 0 <= score <= 1 or not 0 <= threshold <= 1:
+                raise ValueError(
+                    "DeepEval %s built-in score and threshold must be in [0, 1]" % metric_path
+                )
+            target, direction = mapping[name]
+            expected_success = score >= threshold if direction == "higher" else score <= threshold
+            if metric_success != expected_success:
+                raise ValueError(
+                    "DeepEval %s has inconsistent score/threshold success evidence" % metric_path
+                )
+            scores.setdefault(target, []).append(score)
+
+        if suite is not None and names != suite:
+            raise ValueError("DeepEval every test result must contain the same metric suite")
+        suite = names
+        if success != all(metric_successes):
+            raise ValueError("DeepEval %s has inconsistent test success evidence" % row_path)
+        successes += int(success)
+
+    metrics = {
+        "test_cases": MetricValue(value=len(rows), unit="count", direction="neutral"),
+        "deepeval_pass_rate": MetricValue(
+            value=successes / len(rows), unit="ratio", direction="higher"
+        ),
+    }
+    directions = {target: direction for target, direction in mapping.values()}
+    for target, values in scores.items():
+        metrics[target] = MetricValue(
+            value=math.fsum(values) / len(rows), unit="ratio", direction=directions[target]
+        )
+
+    metadata: Dict[str, Any] = {
+        "adapter": "evalforge.deepeval",
+        "adapter_mapping_version": ADAPTER_MAPPING_VERSION,
+        "source_format": "EvaluationResult.model_dump(mode=json,by_alias=False)",
+        "source_schema_commit": SUPPORTED_VERSIONS[version],
+    }
+    if dataset_fingerprint is not None:
+        metadata["dataset_fingerprint"] = dataset_fingerprint
+    return EvaluationArtifact(
+        producer=ArtifactProducer(name="deepeval", version=version),
+        run=ArtifactRun(source_revision=source_revision),
+        metrics=metrics,
+        metadata=metadata,
+    )
+
+
+def _unique_object(pairs: List[Tuple[str, Any]]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("DeepEval export contains duplicate JSON object keys")
+        result[key] = value
+    return result
+
+
+def _reject_constant(value: str) -> Any:
+    raise ValueError("DeepEval export contains a non-standard numeric JSON constant")
+
+
+def load_deepeval_export(
+    path: Path,
+    *,
+    producer_version: str,
+    source_revision: Optional[str] = None,
+    dataset_fingerprint: Optional[str] = None,
+) -> EvaluationArtifact:
+    """Read one explicit DeepEval JSON export without importing DeepEval itself."""
+
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_unique_object,
+            parse_constant=_reject_constant,
+        )
+    except OSError as exc:
+        raise ValueError("Could not read DeepEval export") from exc
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError("DeepEval export is not valid UTF-8 JSON") from exc
+    return deepeval_artifact_from_export(
+        payload,
+        producer_version=producer_version,
+        source_revision=source_revision,
+        dataset_fingerprint=dataset_fingerprint,
+    )

--- a/src/evalforge/adapters/promptfoo.py
+++ b/src/evalforge/adapters/promptfoo.py
@@ -60,7 +60,8 @@ def _optional_metric(
 
 
 def promptfoo_artifact_from_export(
-    payload: Dict[str, Any], *, source_revision: Optional[str] = None
+    payload: Dict[str, Any], *, source_revision: Optional[str] = None,
+    dataset_fingerprint: Optional[str] = None,
 ) -> EvaluationArtifact:
     """Convert a promptfoo OutputFile with EvaluateSummaryV3 into aggregate evidence.
 
@@ -172,6 +173,10 @@ def promptfoo_artifact_from_export(
         "source_schema_version": PROMPTFOO_SCHEMA_VERSION,
         "source_timestamp": source_timestamp,
     }
+    if dataset_fingerprint is not None:
+        sanitized_metadata["dataset_fingerprint"] = _nonempty_string(
+            dataset_fingerprint, "dataset_fingerprint"
+        )
     if metadata.get("exportedAt") is not None:
         sanitized_metadata["source_exported_at"] = _nonempty_string(
             metadata["exportedAt"], "metadata.exportedAt"
@@ -188,7 +193,8 @@ def promptfoo_artifact_from_export(
 
 
 def load_promptfoo_export(
-    path: Path, *, source_revision: Optional[str] = None
+    path: Path, *, source_revision: Optional[str] = None,
+    dataset_fingerprint: Optional[str] = None,
 ) -> EvaluationArtifact:
     """Read and convert a promptfoo JSON export from disk."""
 
@@ -198,4 +204,6 @@ def load_promptfoo_export(
         raise ValueError("Could not read promptfoo export %s: %s" % (path, exc)) from exc
     except json.JSONDecodeError as exc:
         raise ValueError("promptfoo export %s is not valid JSON: %s" % (path, exc)) from exc
-    return promptfoo_artifact_from_export(payload, source_revision=source_revision)
+    return promptfoo_artifact_from_export(
+        payload, source_revision=source_revision, dataset_fingerprint=dataset_fingerprint
+    )

--- a/src/evalforge/adapters/ragas.py
+++ b/src/evalforge/adapters/ragas.py
@@ -1,0 +1,173 @@
+"""Import explicit Ragas score columns from a pandas records JSON export."""
+
+import json
+import math
+from pathlib import Path
+from statistics import mean
+from typing import Any, Dict, List, Optional, Tuple
+
+from evalforge.artifacts import (
+    ArtifactProducer,
+    ArtifactRun,
+    EvaluationArtifact,
+    MetricValue,
+)
+
+ADAPTER_MAPPING_VERSION = "1"
+SOURCE_FORMAT = "ragas.evaluation_result.pandas.records"
+
+# These are sample data in Ragas, including names used by older dataset schemas.
+# A numeric-looking reference or response is never evaluation score evidence.
+_SAMPLE_COLUMNS = {
+    "user_input",
+    "retrieved_contexts",
+    "reference_contexts",
+    "response",
+    "multi_responses",
+    "reference",
+    "rubric",
+    "rubrics",
+    "reference_tool_calls",
+    "reference_topics",
+    "question",
+    "answer",
+    "contexts",
+    "ground_truth",
+    "ground_truths",
+}
+
+
+def _nonempty_string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("Ragas %s must be a non-empty string" % name)
+    return value.strip()
+
+
+def _metric_columns(metrics: List[str]) -> List[str]:
+    if not isinstance(metrics, list) or not metrics:
+        raise ValueError("Ragas metrics must be an explicit non-empty list of score columns")
+    columns: List[str] = []
+    for column in metrics:
+        name = _nonempty_string(column, "metric column")
+        if name != column:
+            raise ValueError("Ragas metric columns must not have surrounding whitespace")
+        if name in _SAMPLE_COLUMNS:
+            raise ValueError("Ragas metric column %s is a reserved dataset column" % name)
+        if name == "test_cases":
+            raise ValueError("Ragas metric column test_cases is reserved for the sample count")
+        if name in columns:
+            raise ValueError("Ragas metric columns must be unique")
+        columns.append(name)
+    return columns
+
+
+def _finite_score(value: Any, index: int, column: str) -> float:
+    message = "Ragas row %s score column %s must be a finite number" % (index, column)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(message)
+    try:
+        number = float(value)
+    except OverflowError as exc:
+        raise ValueError(message) from exc
+    if not math.isfinite(number):
+        raise ValueError(message)
+    return number
+
+
+def ragas_artifact_from_export(
+    payload: Any,
+    *,
+    producer_version: str,
+    metrics: List[str],
+    source_revision: Optional[str] = None,
+    dataset_fingerprint: Optional[str] = None,
+) -> EvaluationArtifact:
+    """Aggregate selected columns of EvaluationResult.to_pandas() JSON records.
+
+    Every selected score must be finite on every row. No rows are dropped, and
+    no metric is inferred from dataset columns. The caller supplies provenance
+    because the records format contains neither the SDK version nor a dataset ID.
+    """
+
+    version = _nonempty_string(producer_version, "producer_version")
+    columns = _metric_columns(metrics)
+    if source_revision is not None:
+        source_revision = _nonempty_string(source_revision, "source_revision")
+    if dataset_fingerprint is not None:
+        dataset_fingerprint = _nonempty_string(dataset_fingerprint, "dataset_fingerprint")
+    if not isinstance(payload, list) or not payload:
+        raise ValueError("Ragas export must be a non-empty JSON array of records")
+
+    scores: Dict[str, List[float]] = {column: [] for column in columns}
+    for index, row in enumerate(payload):
+        if not isinstance(row, dict):
+            raise ValueError("Ragas row %s must be a JSON object" % index)
+        for column in columns:
+            if column not in row:
+                raise ValueError("Ragas row %s is missing score column %s" % (index, column))
+            scores[column].append(_finite_score(row[column], index, column))
+
+    # statistics.mean avoids overflow when the sum of finite scores overflows.
+    values = {
+        column: MetricValue(value=mean(scores[column]), unit="score", direction="neutral")
+        for column in columns
+    }
+    values["test_cases"] = MetricValue(value=len(payload), unit="count", direction="neutral")
+    metadata: Dict[str, Any] = {
+        "adapter": "evalforge.ragas",
+        "adapter_mapping_version": ADAPTER_MAPPING_VERSION,
+        "source_format": SOURCE_FORMAT,
+        "aggregation": "mean",
+        "metric_columns": columns,
+    }
+    if dataset_fingerprint is not None:
+        metadata["dataset_fingerprint"] = dataset_fingerprint
+
+    return EvaluationArtifact(
+        producer=ArtifactProducer(name="ragas", version=version),
+        run=ArtifactRun(source_revision=source_revision),
+        metrics=values,
+        metadata=metadata,
+    )
+
+
+def _unique_object(pairs: List[Tuple[str, Any]]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("Ragas export contains duplicate JSON object keys")
+        result[key] = value
+    return result
+
+
+def _invalid_constant(value: str) -> None:
+    raise ValueError("Ragas export contains a non-finite JSON number")
+
+
+def load_ragas_export(
+    path: Path,
+    *,
+    producer_version: str,
+    metrics: List[str],
+    source_revision: Optional[str] = None,
+    dataset_fingerprint: Optional[str] = None,
+) -> EvaluationArtifact:
+    """Read a Ragas pandas records JSON export without importing the Ragas SDK."""
+
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_unique_object,
+            parse_constant=_invalid_constant,
+        )
+    except OSError as exc:
+        raise ValueError("Could not read Ragas export %s: %s" % (path, exc)) from exc
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError("Ragas export %s is not valid UTF-8 JSON" % path) from exc
+    return ragas_artifact_from_export(
+        payload,
+        producer_version=producer_version,
+        metrics=metrics,
+        source_revision=source_revision,
+        dataset_fingerprint=dataset_fingerprint,
+    )

--- a/src/evalforge/artifacts.py
+++ b/src/evalforge/artifacts.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Tuple
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from evalforge import __version__
 
@@ -32,7 +32,7 @@ METRIC_METADATA: Dict[str, Tuple[str, str]] = {
 class MetricValue(BaseModel):
     model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
-    value: float
+    value: float = Field(strict=True)
     unit: str = Field(default="score", min_length=1)
     direction: Literal["higher", "lower", "neutral"] = "neutral"
 
@@ -62,6 +62,14 @@ class EvaluationArtifact(BaseModel):
     run: ArtifactRun = Field(default_factory=ArtifactRun)
     metrics: Dict[str, MetricValue] = Field(min_length=1)
     metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def portable_metadata(self) -> "EvaluationArtifact":
+        try:
+            json.dumps(self.metadata, allow_nan=False)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Artifact metadata must contain portable JSON values") from exc
+        return self
 
 
 def artifact_from_summary(
@@ -114,7 +122,14 @@ def load_artifact(path: Path) -> EvaluationArtifact:
     summary = payload.get("summary", payload)
     if not isinstance(summary, dict):
         raise ValueError("Artifact summary must be a JSON object")
-    return artifact_from_summary(summary, producer_name="external", producer_version="unknown")
+    metadata = {
+        key: summary[key]
+        for key in ("dataset_fingerprint", "metric_version")
+        if key in summary
+    }
+    return artifact_from_summary(
+        summary, producer_name="external", producer_version="unknown", metadata=metadata
+    )
 
 
 def write_artifact(path: Path, artifact: EvaluationArtifact) -> None:

--- a/src/evalforge/cli.py
+++ b/src/evalforge/cli.py
@@ -2,12 +2,19 @@ import json
 import os
 from importlib.util import find_spec
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import typer
 
+from evalforge.adapters.deepeval import load_deepeval_export
 from evalforge.adapters.promptfoo import load_promptfoo_export
-from evalforge.artifacts import artifact_from_summary, load_artifact, write_artifact
+from evalforge.adapters.ragas import load_ragas_export
+from evalforge.artifacts import (
+    EvaluationArtifact,
+    artifact_from_summary,
+    load_artifact,
+    write_artifact,
+)
 from evalforge.gates import (
     GateCheck,
     GatePolicy,
@@ -17,6 +24,7 @@ from evalforge.gates import (
     load_policy,
     render_json,
     render_junit,
+    render_markdown,
     render_sarif,
     render_terminal,
     write_report,
@@ -25,6 +33,13 @@ from evalforge.gates import (
 app = typer.Typer(help="EvalForge command-line tools")
 import_app = typer.Typer(help="Convert an explicit evaluator format to EvalForge evidence")
 app.add_typer(import_app, name="import")
+
+
+def _declare_metric_version(artifact: EvaluationArtifact, value: Optional[str]) -> None:
+    if value is not None:
+        if not value.strip():
+            raise typer.BadParameter("metric-version must be a non-empty identity")
+        artifact.metadata["metric_version"] = value
 
 
 @import_app.command("promptfoo")
@@ -36,15 +51,65 @@ def import_promptfoo(
         "--source-revision",
         help="Candidate source revision evaluated by promptfoo",
     ),
+    dataset_fingerprint: Optional[str] = typer.Option(None, "--dataset-fingerprint"),
+    metric_version: Optional[str] = typer.Option(None, "--metric-version"),
 ) -> None:
     """Convert a promptfoo JSON OutputFile (results schema v3)."""
 
     try:
-        artifact = load_promptfoo_export(source, source_revision=source_revision)
+        artifact = load_promptfoo_export(
+            source, source_revision=source_revision, dataset_fingerprint=dataset_fingerprint
+        )
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
+    _declare_metric_version(artifact, metric_version)
     write_artifact(output, artifact)
     typer.echo("Wrote promptfoo evaluation artifact to %s" % output)
+
+
+@import_app.command("ragas")
+def import_ragas(
+    source: Path,
+    output: Path = typer.Option(..., "--output", "-o"),
+    producer_version: str = typer.Option(..., "--producer-version"),
+    metrics: List[str] = typer.Option(..., "--metric", help="Score column; repeat for each metric"),
+    source_revision: Optional[str] = typer.Option(None, "--source-revision"),
+    dataset_fingerprint: Optional[str] = typer.Option(None, "--dataset-fingerprint"),
+    metric_version: Optional[str] = typer.Option(None, "--metric-version"),
+) -> None:
+    """Convert explicit Ragas to_pandas().to_json(orient='records') score columns."""
+    try:
+        artifact = load_ragas_export(
+            source, producer_version=producer_version, metrics=metrics,
+            source_revision=source_revision, dataset_fingerprint=dataset_fingerprint,
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    _declare_metric_version(artifact, metric_version)
+    write_artifact(output, artifact)
+    typer.echo("Wrote Ragas evaluation artifact to %s" % output)
+
+
+@import_app.command("deepeval")
+def import_deepeval(
+    source: Path,
+    output: Path = typer.Option(..., "--output", "-o"),
+    producer_version: str = typer.Option(..., "--producer-version"),
+    source_revision: Optional[str] = typer.Option(None, "--source-revision"),
+    dataset_fingerprint: Optional[str] = typer.Option(None, "--dataset-fingerprint"),
+    metric_version: Optional[str] = typer.Option(None, "--metric-version"),
+) -> None:
+    """Convert a verified DeepEval EvaluationResult JSON export with built-in metrics."""
+    try:
+        artifact = load_deepeval_export(
+            source, producer_version=producer_version,
+            source_revision=source_revision, dataset_fingerprint=dataset_fingerprint,
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    _declare_metric_version(artifact, metric_version)
+    write_artifact(output, artifact)
+    typer.echo("Wrote DeepEval evaluation artifact to %s" % output)
 
 
 def _require_rag_dependencies() -> None:
@@ -157,6 +222,9 @@ def gate(
     json_output: Optional[Path] = typer.Option(None, "--json", help="Write the gate report"),
     junit_output: Optional[Path] = typer.Option(None, "--junit", help="Write JUnit XML"),
     sarif_output: Optional[Path] = typer.Option(None, "--sarif", help="Write SARIF 2.1.0"),
+    markdown_output: Optional[Path] = typer.Option(
+        None, "--markdown", help="Write a readable CI summary with evidence digests"
+    ),
 ) -> None:
     """Enforce a portable evaluation policy and return a CI-safe exit code."""
 
@@ -175,6 +243,8 @@ def gate(
         write_report(junit_output, render_junit(report))
     if sarif_output:
         write_report(sarif_output, render_sarif(report))
+    if markdown_output:
+        write_report(markdown_output, render_markdown(report))
     if not report.passed:
         raise typer.Exit(code=1)
 
@@ -309,6 +379,7 @@ def check(
     write_report(report_dir / "evalforge-report.json", render_json(report))
     write_report(report_dir / "evalforge-junit.xml", render_junit(report))
     write_report(report_dir / "evalforge.sarif", render_sarif(report))
+    write_report(report_dir / "evalforge-summary.md", render_markdown(report))
     typer.echo(json.dumps(summary, indent=2))
     typer.echo(render_terminal(report))
     typer.echo("Reports: %s" % report_dir.resolve())

--- a/src/evalforge/gates.py
+++ b/src/evalforge/gates.py
@@ -1,6 +1,9 @@
 """Policy-as-code gates and CI report renderers for evaluation artifacts."""
 
+import hashlib
+import html
 import json
+import math
 import operator
 from collections import Counter
 from pathlib import Path
@@ -20,9 +23,19 @@ class GateCheck(BaseModel):
     id: str = Field(pattern=r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
     metric: str = Field(min_length=1)
     op: GateOperator
-    value: float
+    value: float = Field(strict=True)
     severity: Literal["error", "warning"] = "error"
     description: str = ""
+
+
+class ComparisonPolicy(BaseModel):
+    """Opt-in evidence identity requirements, including absolute-only policies."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    require_same_dataset: bool = False
+    require_same_producer: bool = False
+    require_same_metric_version: bool = False
 
 
 class GatePolicy(BaseModel):
@@ -32,6 +45,7 @@ class GatePolicy(BaseModel):
     version: Literal[1] = 1
     name: str = Field(default="EvalForge quality policy", min_length=1)
     checks: List[GateCheck] = Field(min_length=1)
+    comparison: ComparisonPolicy = Field(default_factory=ComparisonPolicy)
 
     @model_validator(mode="after")
     def check_ids_are_unique(self) -> "GatePolicy":
@@ -66,6 +80,7 @@ class GateReport(BaseModel):
     baseline_run_id: Optional[str] = None
     passed: bool
     checks: List[CheckResult]
+    evidence: Dict[str, Any] = Field(default_factory=dict)
 
 
 COMPARATORS: Dict[str, Callable[[float, float], bool]] = {
@@ -108,13 +123,75 @@ def _error_result(check: GateCheck, message: str) -> CheckResult:
     )
 
 
+def _digest(payload: Dict[str, Any]) -> str:
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _artifact_evidence(artifact: EvaluationArtifact) -> Dict[str, Any]:
+    payload = artifact.model_dump(mode="json", by_alias=True, exclude_none=True)
+    identities = {
+        key: value if isinstance(value, str) and value.strip() else None
+        for key in ("dataset_fingerprint", "metric_version")
+        for value in (artifact.metadata.get(key),)
+    }
+    return {
+        "sha256": _digest(payload),
+        "producer": artifact.producer.model_dump(),
+        "run": artifact.run.model_dump(exclude_none=True),
+        **identities,
+    }
+
+
+def _comparison_error(
+    policy: ComparisonPolicy,
+    candidate: EvaluationArtifact,
+    baseline: Optional[EvaluationArtifact],
+) -> Optional[str]:
+    if not any(policy.model_dump().values()):
+        return None
+    if baseline is None:
+        return "Comparison policy requires a baseline artifact"
+    identities = []
+    if policy.require_same_dataset:
+        identities.append("dataset_fingerprint")
+    if policy.require_same_metric_version:
+        identities.append("metric_version")
+    for key in identities:
+        candidate_value = candidate.metadata.get(key)
+        baseline_value = baseline.metadata.get(key)
+        if not all(isinstance(value, str) and value.strip() for value in (
+            candidate_value, baseline_value
+        )):
+            return "Comparison requires a non-empty %s in both artifacts" % key
+        if candidate_value != baseline_value:
+            return "Comparison %s does not match" % key
+    if policy.require_same_producer:
+        for artifact in (candidate, baseline):
+            if (
+                not artifact.producer.name.strip()
+                or not artifact.producer.version.strip()
+                or artifact.producer.version.strip().lower() == "unknown"
+            ):
+                return "Comparison requires a known producer version in both artifacts"
+        if candidate.producer != baseline.producer:
+            return "Comparison producer name or version does not match"
+    return None
+
+
 def evaluate_gate(
     policy: GatePolicy,
     candidate: EvaluationArtifact,
     baseline: Optional[EvaluationArtifact] = None,
 ) -> GateReport:
     results: List[CheckResult] = []
+    comparison_error = _comparison_error(policy.comparison, candidate, baseline)
     for check in policy.checks:
+        if comparison_error:
+            results.append(_error_result(check, comparison_error))
+            continue
         candidate_metric = candidate.metrics.get(check.metric)
         if candidate_metric is None:
             results.append(_error_result(check, "Candidate metric is missing: %s" % check.metric))
@@ -159,6 +236,11 @@ def evaluate_gate(
                 continue
             baseline_value = baseline_metric.value
             observed = actual - baseline_value
+            if not math.isfinite(observed):
+                results.append(
+                    _error_result(check, "Metric delta is not finite: %s" % check.metric)
+                )
+                continue
 
         passed = COMPARATORS[check.op](observed, check.value)
         outcome: Literal["pass", "fail", "warn", "error"]
@@ -198,6 +280,12 @@ def evaluate_gate(
         baseline_run_id=baseline.run.id if baseline else None,
         passed=gate_passed,
         checks=results,
+        evidence={
+            "digest_format": "evalforge.canonical-json.v1",
+            "policy_sha256": _digest(policy.model_dump(mode="json", by_alias=True)),
+            "candidate": _artifact_evidence(candidate),
+            "baseline": _artifact_evidence(baseline) if baseline else None,
+        },
     )
 
 
@@ -212,6 +300,51 @@ def render_terminal(report: GateReport) -> str:
 def render_json(report: GateReport) -> str:
     payload = report.model_dump(mode="json", exclude_none=True)
     return json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+
+
+def _markdown_text(value: Any) -> str:
+    text = html.escape(str(value), quote=True)
+    for char in ("\\", "`", "*", "_", "[", "]"):
+        text = text.replace(char, "\\" + char)
+    return text.replace("|", "&#124;").replace("\r", " ").replace("\n", " ")
+
+
+def render_markdown(report: GateReport) -> str:
+    """A self-contained CI summary; input text never becomes HTML or table syntax."""
+    lines = [
+        "## EvalForge gate: %s" % ("PASS" if report.passed else "FAIL"),
+        "", "Policy: %s" % _markdown_text(report.policy_name), "",
+        "| Check | Result | Candidate | Baseline | Observed | Requirement |",
+        "| --- | --- | ---: | ---: | ---: | --- |",
+    ]
+    for check in report.checks:
+        numbers = ["—" if value is None else "%.6g" % value for value in (
+            check.actual, check.baseline, check.observed
+        )]
+        lines.append("| %s | %s | %s | %s | %s | %s %.6g |" % (
+            _markdown_text(check.id), check.outcome.upper(), numbers[0], numbers[1], numbers[2],
+            _markdown_text(OPERATOR_LABELS[check.op]), check.expected,
+        ))
+    for check in report.checks:
+        if check.outcome != "pass":
+            lines.extend(["", "- **%s**: %s" % (
+                _markdown_text(check.id), _markdown_text(check.message)
+            )])
+    if report.evidence:
+        lines.extend(["", "### Evidence", ""])
+        for label in ("candidate", "baseline"):
+            evidence = report.evidence.get(label)
+            if not evidence:
+                continue
+            producer = evidence["producer"]
+            lines.append("- %s: %s %s; revision %s; SHA-256 `%s`" % (
+                label.capitalize(), _markdown_text(producer["name"]),
+                _markdown_text(producer["version"]),
+                _markdown_text(evidence["run"].get("source_revision", "unspecified")),
+                evidence["sha256"],
+            ))
+        lines.append("- Policy SHA-256: `%s`" % report.evidence["policy_sha256"])
+    return "\n".join(lines) + "\n"
 
 
 def render_junit(report: GateReport) -> str:
@@ -229,6 +362,10 @@ def render_junit(report: GateReport) -> str:
     )
     properties = ElementTree.SubElement(suite, "properties")
     ElementTree.SubElement(properties, "property", {"name": "policy", "value": report.policy_name})
+    if report.evidence:
+        ElementTree.SubElement(properties, "property", {
+            "name": "evalforge.evidence", "value": json.dumps(report.evidence, allow_nan=False)
+        })
     for result in report.checks:
         case = ElementTree.SubElement(
             suite,
@@ -294,6 +431,7 @@ def render_sarif(report: GateReport) -> str:
                     {"executionSuccessful": True, "exitCode": 0 if report.passed else 1}
                 ],
                 "results": results,
+                "properties": {"evalforgeEvidence": report.evidence},
             }
         ],
     }

--- a/tests/fixtures/deepeval/README.md
+++ b/tests/fixtures/deepeval/README.md
@@ -1,0 +1,48 @@
+# DeepEval fixture provenance
+
+These fixtures contain synthetic scores and text authored for EvalForge. They
+were serialized with the **actual installed DeepEval model classes** using
+`EvaluationResult.model_dump(mode="json", by_alias=False)`. They are not measured
+LLM evaluation results and do not establish model quality or integration adoption.
+
+| Fixture | Installed package | Upstream tag | Pinned commit |
+| --- | --- | --- | --- |
+| `evaluation-result-3.8.1.json` | `deepeval==3.8.1` | `v3.8.1` | `fc268fa3fc04e0f5ebb25db3631788913c02b38a` |
+| `evaluation-result-4.2.2.json` | `deepeval==4.2.2` | `python-v4.2.2` | `f94d940c1e5afc4b280420fe73fe17d146274018` |
+
+Verified on 2026-09-10 against the upstream sources and PyPI packages. The
+`generate.py` script constructs `TestResult` and `MetricData`, then serializes the
+containing `EvaluationResult`. It disables dotenv loading, telemetry, and update
+checks and installs a Python audit hook that blocks DNS/connection attempts. It
+does not call `evaluate()`, instantiate a metric/judge, or send a model request.
+Package installation requires network access; fixture generation does not.
+
+Reproduce in a disposable environment, running once per supported version:
+
+```bash
+python -m venv /tmp/evalforge-deepeval-fixtures
+/tmp/evalforge-deepeval-fixtures/bin/python -m pip install 'deepeval==3.8.1'
+/tmp/evalforge-deepeval-fixtures/bin/python tests/fixtures/deepeval/generate.py
+/tmp/evalforge-deepeval-fixtures/bin/python -m pip install 'deepeval==4.2.2'
+/tmp/evalforge-deepeval-fixtures/bin/python tests/fixtures/deepeval/generate.py
+```
+
+The generator intentionally puts `must-not-leak` markers in raw prompts,
+responses, context, metric reasons/logs/model identifiers, custom metric names,
+test names, run identifiers, links, and metadata. Tests require these markers to
+be absent from the imported artifact.
+
+Source contracts:
+
+- [3.8.1 EvaluationResult and TestResult](https://github.com/confident-ai/deepeval/blob/fc268fa3fc04e0f5ebb25db3631788913c02b38a/deepeval/evaluate/types.py)
+- [3.8.1 MetricData](https://github.com/confident-ai/deepeval/blob/fc268fa3fc04e0f5ebb25db3631788913c02b38a/deepeval/tracing/api.py)
+- [4.2.2 EvaluationResult and TestResult](https://github.com/confident-ai/deepeval/blob/f94d940c1e5afc4b280420fe73fe17d146274018/deepeval/evaluate/types.py)
+- [4.2.2 MetricData](https://github.com/confident-ai/deepeval/blob/f94d940c1e5afc4b280420fe73fe17d146274018/deepeval/tracing/api.py)
+- [3.8.1 Hallucination score and success rule](https://github.com/confident-ai/deepeval/blob/fc268fa3fc04e0f5ebb25db3631788913c02b38a/deepeval/metrics/hallucination/hallucination.py)
+- [4.2.2 Hallucination score](https://github.com/confident-ai/deepeval/blob/f94d940c1e5afc4b280420fe73fe17d146274018/deepeval/metrics/hallucination/hallucination.py)
+- [4.2.2 common success rule](https://github.com/confident-ai/deepeval/blob/f94d940c1e5afc4b280420fe73fe17d146274018/deepeval/metrics/base_metric.py)
+
+DeepEval is Apache-2.0 licensed; see the
+[upstream license](https://github.com/confident-ai/deepeval/blob/f94d940c1e5afc4b280420fe73fe17d146274018/LICENSE.md).
+The generator and synthetic data were written for EvalForge; no upstream model
+implementation is vendored.

--- a/tests/fixtures/deepeval/evaluation-result-3.8.1.json
+++ b/tests/fixtures/deepeval/evaluation-result-3.8.1.json
@@ -1,0 +1,177 @@
+{
+  "test_results": [
+    {
+      "name": "must-not-leak-test-name-0",
+      "success": true,
+      "metrics_data": [
+        {
+          "name": "Answer Relevancy",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.9,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "evaluation_model": "must-not-leak-model",
+          "error": null,
+          "evaluation_cost": null,
+          "verbose_logs": "must-not-leak-logs"
+        },
+        {
+          "name": "Hallucination",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.1,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "verbose_logs": null
+        },
+        {
+          "name": "must-not-leak-custom-metric-name",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.7,
+          "reason": null,
+          "strict_mode": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "verbose_logs": null
+        }
+      ],
+      "conversational": false,
+      "multimodal": null,
+      "input": "must-not-leak-prompt",
+      "actual_output": "must-not-leak-output",
+      "expected_output": "must-not-leak-expected-output",
+      "context": [
+        "must-not-leak-context"
+      ],
+      "retrieval_context": [
+        "must-not-leak-retrieval-context"
+      ],
+      "turns": null,
+      "additional_metadata": {
+        "secret": "must-not-leak-metadata"
+      }
+    },
+    {
+      "name": "must-not-leak-test-name-1",
+      "success": false,
+      "metrics_data": [
+        {
+          "name": "Answer Relevancy",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.6,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "evaluation_model": "must-not-leak-model",
+          "error": null,
+          "evaluation_cost": null,
+          "verbose_logs": "must-not-leak-logs"
+        },
+        {
+          "name": "Hallucination",
+          "threshold": 0.5,
+          "success": false,
+          "score": 0.8,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "verbose_logs": null
+        },
+        {
+          "name": "must-not-leak-custom-metric-name",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.7,
+          "reason": null,
+          "strict_mode": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "verbose_logs": null
+        }
+      ],
+      "conversational": false,
+      "multimodal": null,
+      "input": "must-not-leak-prompt",
+      "actual_output": "must-not-leak-output",
+      "expected_output": "must-not-leak-expected-output",
+      "context": [
+        "must-not-leak-context"
+      ],
+      "retrieval_context": [
+        "must-not-leak-retrieval-context"
+      ],
+      "turns": null,
+      "additional_metadata": {
+        "secret": "must-not-leak-metadata"
+      }
+    },
+    {
+      "name": "must-not-leak-test-name-2",
+      "success": true,
+      "metrics_data": [
+        {
+          "name": "Answer Relevancy",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.8,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "evaluation_model": "must-not-leak-model",
+          "error": null,
+          "evaluation_cost": null,
+          "verbose_logs": "must-not-leak-logs"
+        },
+        {
+          "name": "Hallucination",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.2,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "verbose_logs": null
+        },
+        {
+          "name": "must-not-leak-custom-metric-name",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.7,
+          "reason": null,
+          "strict_mode": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "verbose_logs": null
+        }
+      ],
+      "conversational": false,
+      "multimodal": null,
+      "input": "must-not-leak-prompt",
+      "actual_output": "must-not-leak-output",
+      "expected_output": "must-not-leak-expected-output",
+      "context": [
+        "must-not-leak-context"
+      ],
+      "retrieval_context": [
+        "must-not-leak-retrieval-context"
+      ],
+      "turns": null,
+      "additional_metadata": {
+        "secret": "must-not-leak-metadata"
+      }
+    }
+  ],
+  "confident_link": "https://example.invalid/must-not-leak-confident-link",
+  "test_run_id": "must-not-leak-run-id"
+}

--- a/tests/fixtures/deepeval/evaluation-result-4.2.2.json
+++ b/tests/fixtures/deepeval/evaluation-result-4.2.2.json
@@ -1,0 +1,207 @@
+{
+  "test_results": [
+    {
+      "name": "must-not-leak-test-name-0",
+      "success": true,
+      "metrics_data": [
+        {
+          "name": "Answer Relevancy",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.9,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "flaky": false,
+          "evaluation_model": "must-not-leak-model",
+          "error": null,
+          "evaluation_cost": null,
+          "input_tokens": null,
+          "output_tokens": null,
+          "verbose_logs": "must-not-leak-logs"
+        },
+        {
+          "name": "Hallucination",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.9,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "flaky": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "input_tokens": null,
+          "output_tokens": null,
+          "verbose_logs": null
+        },
+        {
+          "name": "must-not-leak-custom-metric-name",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.7,
+          "reason": null,
+          "strict_mode": false,
+          "flaky": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "input_tokens": null,
+          "output_tokens": null,
+          "verbose_logs": null
+        }
+      ],
+      "conversational": false,
+      "index": null,
+      "multimodal": null,
+      "input": "must-not-leak-prompt",
+      "actual_output": "must-not-leak-output",
+      "expected_output": "must-not-leak-expected-output",
+      "context": [
+        "must-not-leak-context"
+      ],
+      "retrieval_context": [
+        "must-not-leak-retrieval-context"
+      ],
+      "turns": null,
+      "metadata": {
+        "secret": "must-not-leak-metadata"
+      }
+    },
+    {
+      "name": "must-not-leak-test-name-1",
+      "success": false,
+      "metrics_data": [
+        {
+          "name": "Answer Relevancy",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.6,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "flaky": false,
+          "evaluation_model": "must-not-leak-model",
+          "error": null,
+          "evaluation_cost": null,
+          "input_tokens": null,
+          "output_tokens": null,
+          "verbose_logs": "must-not-leak-logs"
+        },
+        {
+          "name": "Hallucination",
+          "threshold": 0.5,
+          "success": false,
+          "score": 0.19999999999999996,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "flaky": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "input_tokens": null,
+          "output_tokens": null,
+          "verbose_logs": null
+        },
+        {
+          "name": "must-not-leak-custom-metric-name",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.7,
+          "reason": null,
+          "strict_mode": false,
+          "flaky": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "input_tokens": null,
+          "output_tokens": null,
+          "verbose_logs": null
+        }
+      ],
+      "conversational": false,
+      "index": null,
+      "multimodal": null,
+      "input": "must-not-leak-prompt",
+      "actual_output": "must-not-leak-output",
+      "expected_output": "must-not-leak-expected-output",
+      "context": [
+        "must-not-leak-context"
+      ],
+      "retrieval_context": [
+        "must-not-leak-retrieval-context"
+      ],
+      "turns": null,
+      "metadata": {
+        "secret": "must-not-leak-metadata"
+      }
+    },
+    {
+      "name": "must-not-leak-test-name-2",
+      "success": true,
+      "metrics_data": [
+        {
+          "name": "Answer Relevancy",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.8,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "flaky": false,
+          "evaluation_model": "must-not-leak-model",
+          "error": null,
+          "evaluation_cost": null,
+          "input_tokens": null,
+          "output_tokens": null,
+          "verbose_logs": "must-not-leak-logs"
+        },
+        {
+          "name": "Hallucination",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.8,
+          "reason": "must-not-leak-reason",
+          "strict_mode": false,
+          "flaky": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "input_tokens": null,
+          "output_tokens": null,
+          "verbose_logs": null
+        },
+        {
+          "name": "must-not-leak-custom-metric-name",
+          "threshold": 0.5,
+          "success": true,
+          "score": 0.7,
+          "reason": null,
+          "strict_mode": false,
+          "flaky": false,
+          "evaluation_model": null,
+          "error": null,
+          "evaluation_cost": null,
+          "input_tokens": null,
+          "output_tokens": null,
+          "verbose_logs": null
+        }
+      ],
+      "conversational": false,
+      "index": null,
+      "multimodal": null,
+      "input": "must-not-leak-prompt",
+      "actual_output": "must-not-leak-output",
+      "expected_output": "must-not-leak-expected-output",
+      "context": [
+        "must-not-leak-context"
+      ],
+      "retrieval_context": [
+        "must-not-leak-retrieval-context"
+      ],
+      "turns": null,
+      "metadata": {
+        "secret": "must-not-leak-metadata"
+      }
+    }
+  ],
+  "confident_link": "https://example.invalid/must-not-leak-confident-link",
+  "test_run_id": "must-not-leak-run-id"
+}

--- a/tests/fixtures/deepeval/generate.py
+++ b/tests/fixtures/deepeval/generate.py
@@ -1,0 +1,88 @@
+"""Serialize synthetic data using the installed, pinned DeepEval model classes.
+
+Run separately with deepeval==3.8.1 and deepeval==4.2.2. No model is created,
+evaluate() is never called, and an audit hook blocks outbound connections.
+"""
+
+import json
+import os
+import sys
+from importlib.metadata import version
+from pathlib import Path
+
+
+def _block_network(event, args):
+    if event in {"socket.connect", "socket.getaddrinfo"}:
+        raise RuntimeError("Fixture generation must remain offline")
+
+
+def main():
+    producer_version = version("deepeval")
+    if producer_version not in {"3.8.1", "4.2.2"}:
+        raise SystemExit("Install deepeval==3.8.1 or deepeval==4.2.2 first")
+    os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"] = "1"
+    os.environ["DEEPEVAL_UPDATE_WARNING_OPT_IN"] = "0"
+    os.environ["DEEPEVAL_DISABLE_DOTENV"] = "1"
+    sys.addaudithook(_block_network)
+
+    from deepeval.evaluate.types import EvaluationResult, TestResult
+    from deepeval.test_run.api import MetricData
+
+    legacy = producer_version == "3.8.1"
+    results = []
+    for index, (relevancy, hallucination) in enumerate([(0.9, 0.1), (0.6, 0.8), (0.8, 0.2)]):
+        metadata_field = "additional_metadata" if legacy else "metadata"
+        score = hallucination if legacy else 1 - hallucination
+        results.append(
+            TestResult(
+                name="must-not-leak-test-name-%s" % index,
+                success=index != 1,
+                conversational=False,
+                input="must-not-leak-prompt",
+                actual_output="must-not-leak-output",
+                expected_output="must-not-leak-expected-output",
+                context=["must-not-leak-context"],
+                retrieval_context=["must-not-leak-retrieval-context"],
+                metrics_data=[
+                    MetricData(
+                        name="Answer Relevancy",
+                        score=relevancy,
+                        threshold=0.5,
+                        success=True,
+                        reason="must-not-leak-reason",
+                        evaluationModel="must-not-leak-model",
+                        verboseLogs="must-not-leak-logs",
+                    ),
+                    MetricData(
+                        name="Hallucination",
+                        score=score,
+                        threshold=0.5,
+                        success=index != 1,
+                        reason="must-not-leak-reason",
+                    ),
+                    MetricData(
+                        name="must-not-leak-custom-metric-name",
+                        score=0.7,
+                        threshold=0.5,
+                        success=True,
+                    ),
+                ],
+                **{metadata_field: {"secret": "must-not-leak-metadata"}},
+            )
+        )
+    result = EvaluationResult(
+        test_results=results,
+        confident_link="https://example.invalid/must-not-leak-confident-link",
+        test_run_id="must-not-leak-run-id",
+    )
+    destination = Path(__file__).parent / ("evaluation-result-%s.json" % producer_version)
+    destination.write_text(
+        json.dumps(result.model_dump(mode="json", by_alias=False), indent=2, allow_nan=False)
+        + "\n",
+        encoding="utf-8",
+    )
+    print("Wrote %s using DeepEval %s model classes" % (destination.name, producer_version))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/ragas/README.md
+++ b/tests/fixtures/ragas/README.md
@@ -1,0 +1,46 @@
+# Ragas fixture provenance
+
+`evaluation-result-records.json` contains invented sample content and scores.
+It represents this specific serialization of an existing Ragas result:
+
+```python
+result.to_pandas().to_json(orient="records", indent=2)
+```
+
+The export path was verified against Ragas **0.2.12**, upstream commit
+[`f5bc2b5e7628f5c68d824e085c4edc17840080b1`](https://github.com/vibrantlabsai/ragas/blob/f5bc2b5e7628f5c68d824e085c4edc17840080b1/src/ragas/dataset_schema.py).
+`EvaluationResult.to_pandas()` concatenates dataset fields with per-row scores.
+The [pandas records orientation](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html)
+serializes that table as an array of row objects, and converts missing numeric
+values to JSON `null`.
+
+During fixture preparation, the upstream `EvaluationResult.to_pandas` method
+body was extracted with Python's AST parser and executed with pandas **2.3.3**,
+the synthetic score dictionaries, and a small dataset shim exposing `__len__`
+and `to_pandas`. Its records JSON was checked for semantic equality with this
+fixture and then saved here. The full Ragas package was not installed or run;
+no model, paid API, or real user data was used. This verifies the serialization
+path, not model scoring or every Ragas release.
+
+To reproduce in an environment that already has Ragas 0.2.12 and pandas:
+
+```python
+import json
+from pathlib import Path
+
+from ragas import EvaluationDataset
+from ragas.dataset_schema import EvaluationResult
+
+path = Path("tests/fixtures/ragas/evaluation-result-records.json")
+rows = json.loads(path.read_text())
+columns = {"faithfulness", "answer_relevancy", "answer_correctness"}
+samples = [{k: v for k, v in row.items() if k not in columns} for row in rows]
+scores = [{k: v for k, v in row.items() if k in columns} for row in rows]
+result = EvaluationResult(scores=scores, dataset=EvaluationDataset.from_list(samples))
+assert json.loads(result.to_pandas().to_json(orient="records")) == rows
+```
+
+The reproduction snippet constructs a result from synthetic scores; it does not
+run an evaluation. Ragas is Apache-2.0 licensed; its
+[license](https://github.com/vibrantlabsai/ragas/blob/f5bc2b5e7628f5c68d824e085c4edc17840080b1/LICENSE)
+is available upstream. The fixture's content was authored for EvalForge.

--- a/tests/fixtures/ragas/evaluation-result-records.json
+++ b/tests/fixtures/ragas/evaluation-result-records.json
@@ -1,0 +1,24 @@
+[
+  {
+    "user_input":"must-not-leak: synthetic question one",
+    "retrieved_contexts":[
+      "must-not-leak: synthetic retrieved context one"
+    ],
+    "response":"must-not-leak: synthetic response one",
+    "reference":"must-not-leak: synthetic reference one",
+    "faithfulness":1.0,
+    "answer_relevancy":0.8,
+    "answer_correctness":0.6
+  },
+  {
+    "user_input":"must-not-leak: synthetic question two",
+    "retrieved_contexts":[
+      "must-not-leak: synthetic retrieved context two"
+    ],
+    "response":"must-not-leak: synthetic response two",
+    "reference":"must-not-leak: synthetic reference two",
+    "faithfulness":0.5,
+    "answer_relevancy":1.0,
+    "answer_correctness":0.4
+  }
+]

--- a/tests/test_action_execution.py
+++ b/tests/test_action_execution.py
@@ -1,0 +1,43 @@
+"""Exercise the actual composite Action shell, including a stale-summary failure."""
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("status,write_summary", [(0, True), (1, True), (2, False), (1, False)])
+def test_action_keeps_status_and_never_appends_old_summary(tmp_path, status, write_summary):
+    mock = tmp_path / "evalforge"
+    mock.write_text(
+        '#!/bin/bash\n'
+        'while [[ "$#" -gt 0 ]]; do\n'
+        '  if [[ "$1" == "--markdown" ]]; then\n'
+        '    shift\n'
+        + ('    echo "CURRENT GATE" > "$1"\n' if write_summary else '    :\n')
+        + '  fi\n  shift\ndone\nexit %s\n' % status
+    )
+    mock.chmod(0o755)
+    markdown = tmp_path / "old summary.md"
+    markdown.write_text("OLD PASS SUMMARY\n")
+    summary = tmp_path / "job-summary"
+    summary.touch()
+    output = tmp_path / "job-output"
+    script = textwrap.dedent((ROOT / "action.yml").read_text().rsplit("run: |", 1)[1])
+    env = {
+        **os.environ, "PATH": str(tmp_path) + os.pathsep + os.environ["PATH"],
+        "EVALFORGE_CANDIDATE": "candidate with spaces.json", "EVALFORGE_BASELINE": "",
+        "EVALFORGE_POLICY": "policy.json", "EVALFORGE_JSON": "report.json",
+        "EVALFORGE_JUNIT": "report.xml", "EVALFORGE_SARIF": "report.sarif",
+        "EVALFORGE_MARKDOWN": str(markdown), "EVALFORGE_JOB_SUMMARY": "true",
+        "GITHUB_OUTPUT": str(output), "GITHUB_STEP_SUMMARY": str(summary),
+    }
+    result = subprocess.run(["bash", "-eo", "pipefail", "-c", script], env=env, cwd=tmp_path)
+    assert result.returncode == status
+    assert output.read_text() == "exit-code=%s\n" % status
+    assert "OLD PASS SUMMARY" not in summary.read_text()
+    assert ("CURRENT GATE" in summary.read_text()) == write_summary

--- a/tests/test_adapter_cli.py
+++ b/tests/test_adapter_cli.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from evalforge.cli import app
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("adapter,fixture,options", [
+    ("promptfoo", "promptfoo/results-v3.json", []),
+    ("ragas", "ragas/evaluation-result-records.json", [
+        "--producer-version", "0.2.12", "--metric", "faithfulness"
+    ]),
+    ("deepeval", "deepeval/evaluation-result-4.2.2.json", ["--producer-version", "4.2.2"]),
+])
+def test_import_cli_retains_explicit_identity_and_rejects_blank_metric_version(
+    tmp_path, adapter, fixture, options
+):
+    output = tmp_path / "artifact.json"
+    args = ["import", adapter, str(ROOT / "tests/fixtures" / fixture), *options,
+            "--output", str(output), "--source-revision", "revision-1",
+            "--dataset-fingerprint", "dataset-1", "--metric-version", "rubric-1"]
+    result = CliRunner().invoke(app, args)
+    assert result.exit_code == 0, result.output
+    payload = json.loads(output.read_text())
+    assert payload["run"]["source_revision"] == "revision-1"
+    assert payload["metadata"]["dataset_fingerprint"] == "dataset-1"
+    assert payload["metadata"]["metric_version"] == "rubric-1"
+    args[-1] = " "
+    output.unlink()
+    result = CliRunner().invoke(app, args)
+    assert result.exit_code == 2
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("adapter,options", [
+    ("ragas", ["--producer-version", "0.2.12", "--metric", "faithfulness"]),
+    ("deepeval", ["--producer-version", "4.2.2"]),
+])
+def test_invalid_import_has_exit_two_and_no_output(tmp_path, adapter, options):
+    source, output = tmp_path / "invalid.json", tmp_path / "artifact.json"
+    source.write_text('{}')
+    result = CliRunner().invoke(app, [
+        "import", adapter, str(source), *options, "--output", str(output)
+    ])
+    assert result.exit_code == 2
+    assert not output.exists()

--- a/tests/test_artifacts_gates.py
+++ b/tests/test_artifacts_gates.py
@@ -32,7 +32,15 @@ def test_committed_examples_match_normative_json_schemas():
     for name in ["baseline_summary.json", "candidate_summary.json"]:
         payload = json.loads((ROOT / "examples" / name).read_text(encoding="utf-8"))
         jsonschema.validate(payload, artifact_schema)
-    for name in ["quality_policy.json", "promptfoo_policy.json"]:
+    for name in ["baseline", "candidate", "changed-dataset"]:
+        payload = json.loads(
+            (ROOT / "examples/strict-comparison" / (name + ".json")).read_text(encoding="utf-8")
+        )
+        jsonschema.validate(payload, artifact_schema)
+    for name in [
+        "quality_policy.json", "promptfoo_policy.json", "ragas_policy.json",
+        "deepeval_policy.json", "strict-comparison/policy.json",
+    ]:
         policy = json.loads((ROOT / "examples" / name).read_text(encoding="utf-8"))
         jsonschema.validate(policy, policy_schema)
 

--- a/tests/test_deepeval_adapter.py
+++ b/tests/test_deepeval_adapter.py
@@ -1,0 +1,282 @@
+import copy
+import json
+import math
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from evalforge.adapters.deepeval import (
+    SUPPORTED_VERSIONS,
+    deepeval_artifact_from_export,
+    load_deepeval_export,
+)
+from evalforge.gates import evaluate_gate, load_policy
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "deepeval"
+
+
+def _payload(version="4.2.2"):
+    return json.loads((FIXTURES / ("evaluation-result-%s.json" % version)).read_text())
+
+
+def _convert(payload, version="4.2.2"):
+    return deepeval_artifact_from_export(payload, producer_version=version)
+
+
+@pytest.mark.parametrize("version", SUPPORTED_VERSIONS)
+def test_official_model_serialization_becomes_private_schema_valid_artifact(version):
+    artifact = load_deepeval_export(
+        FIXTURES / ("evaluation-result-%s.json" % version),
+        producer_version=version,
+        source_revision="abc123",
+        dataset_fingerprint="sha256:synthetic-example",
+    )
+    assert artifact.producer.name == "deepeval"
+    assert artifact.producer.version == version
+    assert artifact.run.id is None
+    assert artifact.run.source_revision == "abc123"
+    assert artifact.metrics["test_cases"].value == 3
+    assert artifact.metrics["deepeval_pass_rate"].value == pytest.approx(2 / 3)
+    assert artifact.metrics["deepeval_pass_rate"].direction == "higher"
+    assert artifact.metrics["deepeval_answer_relevancy"].value == pytest.approx(2.3 / 3)
+    assert artifact.metrics["deepeval_answer_relevancy"].unit == "ratio"
+    legacy = version == "3.8.1"
+    metric_name = "deepeval_v%s_hallucination" % ("3" if legacy else "4")
+    assert artifact.metrics[metric_name].value == pytest.approx((1.1 if legacy else 1.9) / 3)
+    assert artifact.metrics[metric_name].direction == ("lower" if legacy else "higher")
+    assert set(artifact.metrics) == {
+        "test_cases",
+        "deepeval_pass_rate",
+        "deepeval_answer_relevancy",
+        metric_name,
+    }
+    assert artifact.metadata == {
+        "adapter": "evalforge.deepeval",
+        "adapter_mapping_version": "1",
+        "source_format": "EvaluationResult.model_dump(mode=json,by_alias=False)",
+        "source_schema_commit": SUPPORTED_VERSIONS[version],
+        "dataset_fingerprint": "sha256:synthetic-example",
+    }
+    serialized = artifact.model_dump(mode="json", exclude_none=True, by_alias=True)
+    jsonschema.validate(
+        serialized,
+        json.loads((ROOT / "schemas" / "evaluation-artifact-v1.schema.json").read_text()),
+    )
+    assert "must-not-leak" not in json.dumps(serialized)
+
+
+@pytest.mark.parametrize("version", SUPPORTED_VERSIONS)
+@pytest.mark.parametrize("name", ["Hallucination", "Bias", "Toxicity"])
+def test_reversed_metric_semantics_are_versioned_and_not_inferred_from_success(version, name):
+    payload = _payload(version)
+    legacy = version == "3.8.1"
+    for row in payload["test_results"]:
+        row["success"] = True
+        row["metrics_data"] = [
+            {
+                "name": name,
+                "score": 0.2 if legacy else 0.8,
+                "threshold": 0.5,
+                "success": True,
+                "error": None,
+            }
+        ]
+    artifact = _convert(payload, version)
+    target = "deepeval_v%s_%s" % ("3" if legacy else "4", name.lower())
+    assert artifact.metrics[target].direction == ("lower" if legacy else "higher")
+    payload["test_results"][0]["metrics_data"][0]["score"] = 0.8 if legacy else 0.2
+    with pytest.raises(ValueError, match="inconsistent score/threshold"):
+        _convert(payload, version)
+
+
+@pytest.mark.parametrize(
+    "name,target",
+    [
+        ("Answer Relevancy", "answer_relevancy"),
+        ("Faithfulness", "faithfulness"),
+        ("Contextual Precision", "contextual_precision"),
+        ("Contextual Recall", "contextual_recall"),
+        ("Contextual Relevancy", "contextual_relevancy"),
+        ("Tool Correctness", "tool_correctness"),
+        ("Task Completion", "task_completion"),
+    ],
+)
+def test_builtin_name_allowlist_uses_explicit_namespaced_metrics(name, target):
+    payload = _payload()
+    for row in payload["test_results"]:
+        row["success"] = True
+        row["metrics_data"] = [
+            {
+                "name": name,
+                "score": 0.8,
+                "threshold": 0.5,
+                "success": True,
+            }
+        ]
+    artifact = _convert(payload)
+    metric = artifact.metrics["deepeval_" + target]
+    assert metric.value == pytest.approx(0.8)
+    assert metric.direction == "higher"
+
+
+def test_custom_names_only_export_test_count_and_explicit_verdicts():
+    payload = _payload()
+    for index, row in enumerate(payload["test_results"]):
+        row["success"] = index != 1
+        row["metrics_data"] = [
+            {
+                "name": "must-not-leak-arbitrary-name",
+                "score": 70,
+                "threshold": 50,
+                "success": index != 1,
+            }
+        ]
+    artifact = _convert(payload)
+    assert set(artifact.metrics) == {"test_cases", "deepeval_pass_rate"}
+    assert artifact.metrics["deepeval_pass_rate"].value == pytest.approx(2 / 3)
+    assert "must-not-leak" not in artifact.model_dump_json()
+
+
+def test_unknown_metadata_traces_aliases_and_direction_fields_are_never_copied():
+    payload = _payload()
+    payload["metadata"] = {"source_revision": "must-not-leak-untrusted-revision"}
+    payload["test_results"][0]["trace"] = {"spans": ["must-not-leak-trace"]}
+    payload["test_results"][0]["future_field"] = "must-not-leak-future-field"
+    payload["test_results"][0]["metrics_data"][0]["direction"] = "lower"
+    artifact = _convert(payload)
+    assert "must-not-leak" not in artifact.model_dump_json()
+    assert artifact.run.source_revision is None
+    assert artifact.metrics["deepeval_answer_relevancy"].direction == "higher"
+    assert "dataset_fingerprint" not in artifact.metadata
+
+
+@pytest.mark.parametrize("version", ["", " ", None, True, 4, "3.8.0", "4.2.0", "4.2.3", "5.0.0"])
+def test_unverified_producer_versions_are_rejected(version):
+    with pytest.raises(ValueError, match="producer_version"):
+        _convert(_payload(), version)
+
+
+@pytest.mark.parametrize("payload", [None, [], {}, {"test_results": []}, {"testCases": [{}]}])
+def test_wrong_export_shapes_are_rejected(payload):
+    with pytest.raises(ValueError):
+        _convert(payload)
+
+
+@pytest.mark.parametrize("field", ["name", "success", "conversational", "metrics_data"])
+def test_missing_required_test_result_fields_are_rejected(field):
+    payload = _payload()
+    del payload["test_results"][0][field]
+    with pytest.raises(ValueError, match=field):
+        _convert(payload)
+
+
+@pytest.mark.parametrize("value", [None, [], {}, "must-not-leak-invalid-metrics"])
+def test_empty_or_invalid_metric_suites_are_rejected(value):
+    payload = _payload()
+    payload["test_results"][0]["metrics_data"] = value
+    with pytest.raises(ValueError, match="non-empty JSON array"):
+        _convert(payload)
+
+
+@pytest.mark.parametrize("field", ["score", "threshold"])
+@pytest.mark.parametrize("value", [None, True, "0.9", math.nan, math.inf, -math.inf, 10**400])
+@pytest.mark.parametrize("metric_index", [0, 2])
+def test_invalid_scores_and_thresholds_reject_even_unknown_metrics(field, value, metric_index):
+    payload = _payload()
+    payload["test_results"][0]["metrics_data"][metric_index][field] = value
+    with pytest.raises(ValueError, match="finite number") as exc:
+        _convert(payload)
+    assert "must-not-leak" not in str(exc.value)
+
+
+@pytest.mark.parametrize("field", ["score", "threshold"])
+@pytest.mark.parametrize("value", [-0.1, 1.1])
+def test_builtin_scores_and_thresholds_outside_unit_interval_are_rejected(field, value):
+    payload = _payload()
+    payload["test_results"][0]["metrics_data"][0][field] = value
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        _convert(payload)
+
+
+@pytest.mark.parametrize(
+    "field,value,match",
+    [
+        ("error", "must-not-leak-error", "errored"),
+        ("error", "", "errored"),
+        ("flaky", True, "flaky"),
+        ("flaky", "false", "boolean"),
+        ("success", None, "boolean"),
+        ("success", 1, "boolean"),
+        ("name", "", "non-empty string"),
+    ],
+)
+@pytest.mark.parametrize("metric_index", [0, 2])
+def test_invalid_metrics_fail_closed_without_raw_error_details(field, value, match, metric_index):
+    payload = _payload()
+    payload["test_results"][0]["metrics_data"][metric_index][field] = value
+    with pytest.raises(ValueError, match=match) as exc:
+        _convert(payload)
+    assert "must-not-leak" not in str(exc.value)
+
+
+def test_partial_metric_coverage_cannot_raise_the_aggregate_by_dropping_a_failure():
+    payload = _payload()
+    del payload["test_results"][1]["metrics_data"][1]
+    payload["test_results"][1]["success"] = True
+    with pytest.raises(ValueError, match="same metric suite"):
+        _convert(payload)
+
+
+def test_duplicate_metrics_cannot_reweight_the_average():
+    payload = _payload()
+    metrics = payload["test_results"][0]["metrics_data"]
+    metrics.append(copy.deepcopy(metrics[0]))
+    with pytest.raises(ValueError, match="duplicate metric"):
+        _convert(payload)
+
+
+def test_test_success_must_match_every_metric_verdict():
+    payload = _payload()
+    payload["test_results"][1]["success"] = True
+    with pytest.raises(ValueError, match="inconsistent test success"):
+        _convert(payload)
+
+
+def test_mixed_conversation_modes_are_rejected():
+    payload = _payload()
+    payload["test_results"][1]["conversational"] = True
+    with pytest.raises(ValueError, match="one conversation mode"):
+        _convert(payload)
+
+
+@pytest.mark.parametrize(
+    "content,match",
+    [
+        (b'{"test_results": [], "test_results": []}', "duplicate JSON"),
+        (b'{"secret": NaN}', "non-standard numeric"),
+        (b'{"secret": Infinity}', "non-standard numeric"),
+        (b'{"secret": "must-not-leak",', "not valid UTF-8 JSON"),
+        (b"\xff", "not valid UTF-8 JSON"),
+    ],
+)
+def test_loader_rejects_ambiguous_or_invalid_json_without_content_leaks(tmp_path, content, match):
+    path = tmp_path / "export.json"
+    path.write_bytes(content)
+    with pytest.raises(ValueError, match=match) as exc:
+        load_deepeval_export(path, producer_version="4.2.2")
+    assert "must-not-leak" not in str(exc.value)
+
+
+def test_loader_read_errors_are_actionable(tmp_path):
+    with pytest.raises(ValueError, match="Could not read DeepEval export"):
+        load_deepeval_export(tmp_path / "missing.json", producer_version="4.2.2")
+
+
+def test_example_policy_accepts_current_fixture_and_rejects_legacy_score_semantics():
+    policy = load_policy(ROOT / "examples" / "deepeval_policy.json")
+    assert evaluate_gate(policy, _convert(_payload())).passed
+    legacy_report = evaluate_gate(policy, _convert(_payload("3.8.1"), "3.8.1"))
+    assert not legacy_report.passed
+    assert any(check.outcome == "error" for check in legacy_report.checks)

--- a/tests/test_evidence_comparison.py
+++ b/tests/test_evidence_comparison.py
@@ -1,0 +1,177 @@
+import json
+from xml.etree import ElementTree
+
+import pytest
+from pydantic import ValidationError
+from typer.testing import CliRunner
+
+from evalforge.artifacts import MetricValue, artifact_from_summary, load_artifact, write_artifact
+from evalforge.cli import app
+from evalforge.gates import (
+    ComparisonPolicy,
+    GateCheck,
+    GatePolicy,
+    evaluate_gate,
+    render_junit,
+    render_markdown,
+    render_sarif,
+)
+
+
+def artifact(score=0.9, **metadata):
+    return artifact_from_summary(
+        {"quality": score}, source_revision="abc123",
+        metadata={"dataset_fingerprint": "golden-v1", "metric_version": "judge-v1", **metadata},
+    )
+
+
+def policy(**comparison):
+    return GatePolicy(
+        checks=[GateCheck(id="regression", metric="quality", op="delta_gte", value=-0.05)],
+        comparison=ComparisonPolicy(**comparison),
+    )
+
+
+@pytest.mark.parametrize("key,field", [
+    ("require_same_dataset", "dataset_fingerprint"),
+    ("require_same_metric_version", "metric_version"),
+])
+@pytest.mark.parametrize("value", ["different", None, "", " ", 1, [], {}])
+def test_identity_mismatch_blocks_even_when_candidate_score_is_higher(key, field, value):
+    report = evaluate_gate(policy(**{key: True}), artifact(1.0, **{field: value}), artifact())
+    assert not report.passed
+    assert report.checks[0].outcome == "error"
+    assert field in report.checks[0].message
+
+
+def test_matching_identities_pass_and_legacy_policy_is_unchanged():
+    strict = policy(
+        require_same_dataset=True, require_same_producer=True, require_same_metric_version=True
+    )
+    assert evaluate_gate(strict, artifact(), artifact()).passed
+    assert evaluate_gate(policy(), artifact(dataset_fingerprint="changed"), artifact()).passed
+
+
+def test_strict_context_applies_without_delta_checks_and_cannot_be_advisory():
+    strict = policy(require_same_dataset=True)
+    strict.checks[0] = GateCheck(
+        id="quality", metric="quality", op="gte", value=0.5, severity="warning"
+    )
+    report = evaluate_gate(strict, artifact())
+    assert not report.passed
+    assert "requires a baseline" in report.checks[0].message
+
+
+@pytest.mark.parametrize("producer_name,producer_version", [
+    ("other", "0.4.0"), ("evalforge", "unknown"), ("evalforge", "different")
+])
+def test_producer_identity_must_match_with_known_version(producer_name, producer_version):
+    candidate = artifact_from_summary(
+        {"quality": 1}, producer_name=producer_name, producer_version=producer_version
+    )
+    report = evaluate_gate(policy(require_same_producer=True), candidate, artifact())
+    assert not report.passed
+    assert "producer" in report.checks[0].message
+
+
+def test_blank_producer_identity_cannot_pass_strict_comparison():
+    candidate = artifact_from_summary({"quality": 1}, producer_name=" ", producer_version=" ")
+    report = evaluate_gate(policy(require_same_producer=True), candidate, candidate)
+    assert not report.passed
+
+
+@pytest.mark.parametrize("candidate,baseline", [(1e308, -1e308), (-1e308, 1e308)])
+def test_delta_overflow_fails_closed_and_reports_remain_serializable(candidate, baseline):
+    advisory = policy()
+    advisory.checks[0].severity = "warning"
+    report = evaluate_gate(advisory, artifact(candidate), artifact(baseline))
+    assert not report.passed
+    assert report.checks[0].outcome == "error"
+    assert report.checks[0].observed is None
+    assert "not finite" in report.checks[0].message
+    assert json.dumps(report.model_dump(), allow_nan=False)
+
+
+def test_api_summary_preserves_comparison_identity(tmp_path):
+    path = tmp_path / "summary.json"
+    path.write_text(json.dumps({"summary": {
+        "quality": 0.9, "dataset_fingerprint": "v1", "metric_version": "m1",
+        "answer": "private response"
+    }}))
+    loaded = load_artifact(path)
+    assert loaded.metadata == {"dataset_fingerprint": "v1", "metric_version": "m1"}
+    assert list(loaded.metrics) == ["quality"]
+
+
+@pytest.mark.parametrize("value", [True, False, "0.9", None])
+def test_canonical_numbers_reject_schema_incompatible_coercion(value):
+    with pytest.raises(ValidationError):
+        MetricValue(value=value)
+    with pytest.raises(ValidationError):
+        GateCheck(id="bad", metric="quality", op="gte", value=value)
+
+
+def test_nonportable_metadata_rejected():
+    with pytest.raises(ValueError, match="portable JSON"):
+        artifact(secret=float("nan"))
+
+
+def test_evidence_digests_are_deterministic_and_sensitive_to_input():
+    candidate = artifact()
+    first = evaluate_gate(policy(), candidate, artifact()).evidence
+    assert first == evaluate_gate(policy(), candidate, artifact()).evidence
+    reordered = candidate.model_copy(update={"metadata": dict(reversed(
+        list(candidate.metadata.items())
+    ))})
+    assert first == evaluate_gate(policy(), reordered, artifact()).evidence
+    changed = evaluate_gate(policy(), artifact(0.8), artifact()).evidence
+    assert first["candidate"]["sha256"] != changed["candidate"]["sha256"]
+    assert first["policy_sha256"] == changed["policy_sha256"]
+    modified_policy = policy()
+    modified_policy.checks[0].value = -0.1
+    assert first["policy_sha256"] != evaluate_gate(
+        modified_policy, candidate, artifact()
+    ).evidence["policy_sha256"]
+    assert first["candidate"]["run"]["source_revision"] == "abc123"
+
+
+def test_all_reports_carry_same_evidence_and_markdown_escapes_untrusted_text():
+    strict = policy(require_same_dataset=True)
+    strict.name = "evil | table\n<script>alert(1)</script> [link](https://example.test)"
+    report = evaluate_gate(strict, artifact(dataset_fingerprint="v2"), artifact())
+    markdown = render_markdown(report)
+    assert "EvalForge gate: FAIL" in markdown
+    assert "ERROR" in markdown and "does not match" in markdown
+    assert "<script>" not in markdown
+    assert "evil &#124; table" in markdown
+    assert "\\[link\\]" in markdown
+    assert report.evidence["candidate"]["sha256"] in markdown
+    junit = ElementTree.fromstring(render_junit(report))
+    evidence = junit.find("./properties/property[@name='evalforge.evidence']")
+    assert json.loads(evidence.attrib["value"]) == report.evidence
+    sarif = json.loads(render_sarif(report))
+    assert sarif["runs"][0]["properties"]["evalforgeEvidence"] == report.evidence
+
+
+def test_malformed_identity_does_not_copy_raw_objects_to_reports():
+    candidate = artifact(dataset_fingerprint={"raw_document": "PRIVATE-SENTINEL"})
+    report = evaluate_gate(policy(require_same_dataset=True), candidate, artifact())
+    assert not report.passed
+    assert "PRIVATE-SENTINEL" not in report.model_dump_json()
+    assert "PRIVATE-SENTINEL" not in render_junit(report)
+    assert report.evidence["candidate"]["dataset_fingerprint"] is None
+
+
+def test_cli_writes_failure_summary_and_json_evidence(tmp_path):
+    candidate, baseline, policy_path = (tmp_path / p for p in ("c.json", "b.json", "p.json"))
+    write_artifact(candidate, artifact(dataset_fingerprint="changed"))
+    write_artifact(baseline, artifact())
+    policy_path.write_text(policy(require_same_dataset=True).model_dump_json())
+    markdown, report_path = tmp_path / "summary.md", tmp_path / "report.json"
+    result = CliRunner().invoke(app, [
+        "gate", str(candidate), "--baseline", str(baseline), "--policy", str(policy_path),
+        "--markdown", str(markdown), "--json", str(report_path),
+    ])
+    assert result.exit_code == 1
+    assert "does not match" in markdown.read_text()
+    assert json.loads(report_path.read_text())["evidence"]["candidate"]["sha256"]

--- a/tests/test_ragas_adapter.py
+++ b/tests/test_ragas_adapter.py
@@ -1,0 +1,192 @@
+import json
+import math
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from evalforge.adapters.ragas import load_ragas_export, ragas_artifact_from_export
+from evalforge.gates import evaluate_gate, load_policy
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests" / "fixtures" / "ragas" / "evaluation-result-records.json"
+
+
+def _payload():
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _artifact(payload, **kwargs):
+    options = {"producer_version": "0.2.12", "metrics": ["faithfulness", "answer_relevancy"]}
+    options.update(kwargs)
+    return ragas_artifact_from_export(payload, **options)
+
+
+def test_ragas_records_fixture_produces_schema_valid_aggregate_only_artifact():
+    artifact = load_ragas_export(
+        FIXTURE,
+        producer_version="0.2.12",
+        metrics=["faithfulness", "answer_relevancy"],
+        source_revision="abc123",
+        dataset_fingerprint="sha256:synthetic-dataset",
+    )
+
+    assert artifact.producer.name == "ragas"
+    assert artifact.producer.version == "0.2.12"
+    assert artifact.run.source_revision == "abc123"
+    assert artifact.run.id is None
+    assert set(artifact.metrics) == {"faithfulness", "answer_relevancy", "test_cases"}
+    assert artifact.metrics["faithfulness"].value == pytest.approx(0.75)
+    assert artifact.metrics["answer_relevancy"].value == pytest.approx(0.9)
+    assert artifact.metrics["faithfulness"].unit == "score"
+    assert artifact.metrics["faithfulness"].direction == "neutral"
+    assert artifact.metrics["test_cases"].value == 2
+    assert artifact.metrics["test_cases"].unit == "count"
+    assert artifact.metadata == {
+        "adapter": "evalforge.ragas",
+        "adapter_mapping_version": "1",
+        "source_format": "ragas.evaluation_result.pandas.records",
+        "aggregation": "mean",
+        "metric_columns": ["faithfulness", "answer_relevancy"],
+        "dataset_fingerprint": "sha256:synthetic-dataset",
+    }
+    serialized = artifact.model_dump(mode="json", exclude_none=True, by_alias=True)
+    jsonschema.validate(
+        serialized,
+        json.loads((ROOT / "schemas" / "evaluation-artifact-v1.schema.json").read_text()),
+    )
+    assert "must-not-leak" not in json.dumps(serialized)
+
+
+def test_ragas_preserves_only_selected_scores_even_when_extra_columns_are_numeric():
+    rows = _payload()
+    rows[0]["user_input"] = 123456
+    rows[0]["private_numeric_field"] = 987654321
+    rows[0]["metadata"] = {"api_key": "must-not-leak"}
+    rows[0]["trace"] = ["must-not-leak"]
+    artifact = _artifact(rows, metrics=["answer_correctness"])
+
+    assert set(artifact.metrics) == {"answer_correctness", "test_cases"}
+    assert artifact.metrics["answer_correctness"].value == 0.5
+    # Preserve source scores without equating them with EvalForge's own metrics.
+    assert artifact.metrics["answer_correctness"].unit == "score"
+    assert artifact.metrics["answer_correctness"].direction == "neutral"
+    assert "dataset_fingerprint" not in artifact.metadata
+    assert "987654321" not in artifact.model_dump_json()
+    assert "must-not-leak" not in artifact.model_dump_json()
+
+
+@pytest.mark.parametrize("value", [None, True, False, "0.9", [], {}, math.nan, math.inf, -math.inf])
+def test_ragas_rejects_bad_selected_score_without_dropping_the_row(value):
+    rows = _payload()
+    rows[1]["faithfulness"] = value
+
+    with pytest.raises(ValueError, match="row 1 score column faithfulness.*finite number"):
+        _artifact(rows)
+
+
+def test_ragas_missing_score_fails_instead_of_improving_the_mean():
+    rows = _payload()
+    del rows[1]["faithfulness"]
+
+    with pytest.raises(ValueError, match="row 1 is missing score column faithfulness"):
+        _artifact(rows)
+
+
+@pytest.mark.parametrize("payload", [[], {}, {"faithfulness": 1}, {"scores": []}, None, [None]])
+def test_ragas_rejects_empty_exports_and_other_serialization_formats(payload):
+    with pytest.raises(ValueError, match="JSON"):
+        _artifact(payload)
+
+
+@pytest.mark.parametrize("version", [None, True, 12, "", " \n"])
+def test_ragas_requires_explicit_nonempty_producer_version(version):
+    with pytest.raises(ValueError, match="producer_version"):
+        _artifact(_payload(), producer_version=version)
+
+
+@pytest.mark.parametrize(
+    "metrics",
+    [None, [], "faithfulness", [""], [None], [" faithfulness"], ["faithfulness", "faithfulness"]],
+)
+def test_ragas_requires_an_explicit_unambiguous_metric_allowlist(metrics):
+    with pytest.raises(ValueError, match="metric"):
+        _artifact(_payload(), metrics=metrics)
+
+
+@pytest.mark.parametrize("column", ["user_input", "response", "reference", "ground_truth"])
+def test_ragas_dataset_columns_cannot_be_imported_as_metrics(column):
+    with pytest.raises(ValueError, match="reserved dataset column"):
+        _artifact([{column: 1}], metrics=[column])
+
+
+def test_ragas_sample_count_cannot_be_overwritten_by_a_score_column():
+    with pytest.raises(ValueError, match="reserved for the sample count"):
+        _artifact([{"test_cases": 100000}], metrics=["test_cases"])
+
+
+@pytest.mark.parametrize("field", ["source_revision", "dataset_fingerprint"])
+def test_ragas_optional_provenance_must_not_be_empty(field):
+    with pytest.raises(ValueError, match=field):
+        _artifact(_payload(), **{field: " "})
+
+
+def test_ragas_uses_an_overflow_safe_mean_for_finite_scores():
+    artifact = _artifact([{"custom": 1e308}, {"custom": 1e308}], metrics=["custom"])
+    assert artifact.metrics["custom"].value == 1e308
+
+
+def test_ragas_rejects_integer_scores_that_cannot_be_represented_as_finite_numbers():
+    with pytest.raises(ValueError, match="finite number"):
+        _artifact([{"custom": 10**400}], metrics=["custom"])
+
+
+@pytest.mark.parametrize("content", [b"{", b"\xff"])
+def test_ragas_file_errors_do_not_expose_source_content(tmp_path, content):
+    path = tmp_path / "records.json"
+    path.write_bytes(content)
+    with pytest.raises(ValueError, match="not valid UTF-8 JSON"):
+        load_ragas_export(path, producer_version="0.2.12", metrics=["faithfulness"])
+
+
+def test_ragas_read_error_is_actionable(tmp_path):
+    with pytest.raises(ValueError, match="Could not read Ragas export"):
+        load_ragas_export(
+            tmp_path / "missing.json", producer_version="0.2.12", metrics=["faithfulness"]
+        )
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity", "1e999"])
+def test_ragas_nonfinite_json_score_fails(tmp_path, constant):
+    path = tmp_path / "records.json"
+    path.write_text('[{"faithfulness": %s}]' % constant)
+    with pytest.raises(ValueError, match="finite"):
+        load_ragas_export(path, producer_version="0.2.12", metrics=["faithfulness"])
+
+
+def test_ragas_duplicate_json_keys_cannot_hide_a_bad_score(tmp_path):
+    path = tmp_path / "records.json"
+    path.write_text('[{"faithfulness": null, "faithfulness": 1}]')
+    with pytest.raises(ValueError, match="duplicate JSON object keys"):
+        load_ragas_export(path, producer_version="0.2.12", metrics=["faithfulness"])
+
+
+def test_ragas_invalid_score_error_does_not_repeat_private_value():
+    rows = _payload()
+    rows[0]["faithfulness"] = "private-value-must-not-leak"
+    with pytest.raises(ValueError) as error:
+        _artifact(rows)
+    assert "private-value-must-not-leak" not in str(error.value)
+
+
+def test_ragas_example_policy_passes_fixture_and_catches_regression():
+    policy = load_policy(ROOT / "examples" / "ragas_policy.json")
+    artifact = _artifact(_payload())
+    assert evaluate_gate(policy, artifact).passed
+
+    rows = _payload()
+    rows[1]["faithfulness"] = 0.0
+    report = evaluate_gate(policy, _artifact(rows))
+    assert not report.passed
+    assert report.checks[0].id == "ragas-faithfulness"
+    assert report.checks[0].outcome == "fail"


### PR DESCRIPTION
## Problem
A higher evaluation score can incorrectly pass a release gate after the dataset or metric definition changes. Ragas and DeepEval users also lacked explicit import paths into the portable artifact.

## Change
Add offline Ragas score-column and DeepEval 3.8.1/4.2.2 adapters, including separate names for metrics whose score semantics reversed across major versions. Add opt-in dataset, producer, and metric-version comparison requirements, normalized input/policy SHA-256 digests, and Markdown summaries retained on blocked GitHub Actions runs. Existing flat-summary policies remain compatible.

## Evidence
- [x] 240 tests pass on Python 3.9.6; 89.78% branch-aware coverage
- [x] Ruff and mypy pass
- [x] Wheel/sdist build and Twine checks pass
- [x] Fresh base-only wheel installation runs all three adapters and gates without evaluator, database, or dashboard dependencies
- [x] Dataset-mismatch example blocks with exit 1; Action shell tests preserve failure status and reject stale summaries
- [x] Documented upstream fixtures, complete CI recipe, schema migration, and dated OSS evidence

## Security and data
Importers retain aggregate evidence and explicit provenance. Raw prompts, responses, traces, and arbitrary metadata are excluded. Missing, errored, or non-finite selected scores fail the import; overflowing deltas fail the gate. Digests identify inputs but are not signatures or proof of model quality. Fixtures contain synthetic scores, not adoption evidence.

Remote branch tree was verified byte-for-byte against the locally tested tree: 4596aa2edb3a5ad7a729bc2d3308b0226494dbd7.
